### PR TITLE
1.4.0 — Finance.Returns metrics (cagr, payback, PI, twr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.4.0 — 2026-07-04
+
+### Added
+- `Finance.Returns` return metrics: `cagr/4` (compound annual growth rate),
+  `payback_period/2` and `discounted_payback_period/3` (with fractional-period
+  interpolation), `profitability_index/3` (reusing `CashFlow.npv`), and `twr/2`
+  (time-weighted return, with an optional `:periods_per_year` to annualise) —
+  each with a `!` variant.
+
 ## 1.3.0 — 2026-07-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ The functions are organised into domain modules:
 - `Finance.Bonds` — fixed income (`price`, `ytm`, `duration`,
   `modified_duration`, `convexity`).
 - `Finance.Depreciation` — `sln`, `syd`, `ddb`, `db`.
-- `Finance.Returns` — performance and risk metrics (`volatility`).
+- `Finance.Returns` — performance and risk metrics (`volatility`, `cagr`,
+  `payback_period`, `discounted_payback_period`, `profitability_index`, `twr`).
 - `Finance.Solver` — the root-finding strategy behind the rate functions,
   swappable via the `:solver` option or `config :finance, solver: MySolver`.
 

--- a/lib/finance.ex
+++ b/lib/finance.ex
@@ -14,7 +14,8 @@ defmodule Finance do
     * `Finance.Bonds` — fixed income (`price`, `ytm`, `duration`,
       `modified_duration`, `convexity`).
     * `Finance.Depreciation` — `sln`, `syd`, `ddb`, `db`.
-    * `Finance.Returns` — performance and risk metrics (`volatility`).
+    * `Finance.Returns` — performance and risk metrics (`volatility`, `cagr`,
+      `payback_period`, `discounted_payback_period`, `profitability_index`, `twr`).
     * `Finance.Solver` — the root-finding strategy behind the rate functions,
       swappable via the `:solver` option or `config :finance, solver: MySolver`.
 

--- a/lib/finance/cash_flow.ex
+++ b/lib/finance/cash_flow.ex
@@ -94,11 +94,11 @@ defmodule Finance.CashFlow do
     zip(dates, values, opts)
   end
 
-  @doc "Same as `xirr/1`, but hands back the rate on its own and raises `ArgumentError` if the calculation fails."
+  @doc "Same as `xirr/1`, but returns the rate directly and raises `ArgumentError` on error."
   @spec xirr!([cash_flow]) :: rate
   def xirr!(cash_flows), do: cash_flows |> xirr() |> unwrap!()
 
-  @doc "Same as `xirr/2`, but hands back the rate on its own and raises `ArgumentError` if the calculation fails."
+  @doc "Same as `xirr/2`, but returns the rate directly and raises `ArgumentError` on error."
   @spec xirr!([cash_flow] | [date], [option] | [amount]) :: rate
   def xirr!(first, second), do: first |> xirr(second) |> unwrap!()
 
@@ -143,7 +143,7 @@ defmodule Finance.CashFlow do
     end
   end
 
-  @doc "Same as `xnpv/2`, but hands back the value on its own and raises `ArgumentError` if the calculation fails."
+  @doc "Same as `xnpv/2`, but returns the value directly and raises `ArgumentError` on error."
   @spec xnpv!(rate, [cash_flow]) :: number
   def xnpv!(rate, cash_flows), do: rate |> xnpv(cash_flows) |> unwrap!()
 
@@ -178,7 +178,7 @@ defmodule Finance.CashFlow do
     end
   end
 
-  @doc "Same as `irr/1`, but hands back the rate on its own and raises `ArgumentError` if the calculation fails."
+  @doc "Same as `irr/1`, but returns the rate directly and raises `ArgumentError` on error."
   @spec irr!([amount], [option]) :: rate
   def irr!(amounts, opts \\ []), do: amounts |> irr(opts) |> unwrap!()
 
@@ -218,7 +218,7 @@ defmodule Finance.CashFlow do
     {:ok, round_value(present_value(periodic_flows(amounts), rate), opts)}
   end
 
-  @doc "Same as `npv/2`, but hands back the value on its own and raises `ArgumentError` if the calculation fails."
+  @doc "Same as `npv/2`, but returns the value directly and raises `ArgumentError` on error."
   @spec npv!(rate, [amount]) :: number
   def npv!(rate, amounts), do: rate |> npv(amounts) |> unwrap!()
 
@@ -253,7 +253,7 @@ defmodule Finance.CashFlow do
     end
   end
 
-  @doc "Same as `mirr/3`, but hands back the rate on its own and raises `ArgumentError` if the calculation fails."
+  @doc "Same as `mirr/3`, but returns the rate directly and raises `ArgumentError` on error."
   @spec mirr!([amount], number, number, [option]) :: rate
   def mirr!(amounts, finance_rate, reinvest_rate, opts \\ []) do
     amounts |> mirr(finance_rate, reinvest_rate, opts) |> unwrap!()

--- a/lib/finance/depreciation.ex
+++ b/lib/finance/depreciation.ex
@@ -32,7 +32,7 @@ defmodule Finance.Depreciation do
     end
   end
 
-  @doc "Same as `sln/3`, but hands back the value on its own and raises `ArgumentError` if the calculation fails."
+  @doc "Same as `sln/3`, but returns the value directly and raises `ArgumentError` on error."
   @spec sln!(number, number, number) :: float
   def sln!(cost, salvage, life), do: cost |> sln(salvage, life) |> unwrap!()
 
@@ -61,7 +61,7 @@ defmodule Finance.Depreciation do
     end
   end
 
-  @doc "Same as `syd/4`, but hands back the value on its own and raises `ArgumentError` if the calculation fails."
+  @doc "Same as `syd/4`, but returns the value directly and raises `ArgumentError` on error."
   @spec syd!(number, number, number, number) :: float
   def syd!(cost, salvage, life, period), do: cost |> syd(salvage, life, period) |> unwrap!()
 
@@ -97,7 +97,7 @@ defmodule Finance.Depreciation do
     life > 0 and factor > 0 and period == n and n >= 1 and n <= life
   end
 
-  @doc "Same as `ddb/5`, but hands back the value on its own and raises `ArgumentError` if the calculation fails."
+  @doc "Same as `ddb/5`, but returns the value directly and raises `ArgumentError` on error."
   @spec ddb!(number, number, number, number, number) :: float
   def ddb!(cost, salvage, life, period, factor \\ 2) do
     cost |> ddb(salvage, life, period, factor) |> unwrap!()
@@ -132,7 +132,7 @@ defmodule Finance.Depreciation do
     end
   end
 
-  @doc "Same as `db/5`, but hands back the value on its own and raises `ArgumentError` if the calculation fails."
+  @doc "Same as `db/5`, but returns the value directly and raises `ArgumentError` on error."
   @spec db!(number, number, number, number, number) :: float
   def db!(cost, salvage, life, period, month \\ 12) do
     cost |> db(salvage, life, period, month) |> unwrap!()

--- a/lib/finance/returns.ex
+++ b/lib/finance/returns.ex
@@ -1,14 +1,41 @@
 defmodule Finance.Returns do
   @moduledoc """
-  Performance and risk metrics for a price or return series.
+  Performance and risk metrics.
 
-  For now this covers `volatility/2`; return metrics such as CAGR, payback, and
-  time-weighted return will land here as the library grows.
+  Risk is covered by `volatility/2` (the annualised standard deviation of a price
+  series' returns). The return metrics are `cagr/4` (compound annual growth
+  rate), `payback_period/2` and `discounted_payback_period/3` (time to recover an
+  outlay), `profitability_index/3` (present value of inflows per unit invested),
+  and `twr/2` (time-weighted return).
+
+  The cash-flow functions follow the same convention as `Finance.CashFlow.npv/2`:
+  the initial outlay sits at index 0 (undiscounted) and later flows fall at
+  periods 1, 2, ….
   """
 
   import Finance.Shared, only: [round_value: 2, unwrap!: 1]
 
   @type error :: Finance.error()
+
+  @precision_options_schema NimbleOptions.new!(
+                              precision: [
+                                type: :non_neg_integer,
+                                default: 6,
+                                doc: "decimal places the result is rounded to"
+                              ]
+                            )
+
+  @twr_options_schema NimbleOptions.new!(
+                        periods_per_year: [
+                          type: :pos_integer,
+                          doc: "if given, annualise the result over this many periods a year"
+                        ],
+                        precision: [
+                          type: :non_neg_integer,
+                          default: 6,
+                          doc: "decimal places the result is rounded to"
+                        ]
+                      )
 
   @volatility_options_schema NimbleOptions.new!(
                                periods_per_year: [
@@ -63,9 +90,135 @@ defmodule Finance.Returns do
     end
   end
 
-  @doc "Same as `volatility/2`, but hands back the value on its own and raises `ArgumentError` if it can't be computed."
+  @doc "Same as `volatility/2`, but returns the value directly and raises `ArgumentError` on error."
   @spec volatility!([number], keyword) :: float
   def volatility!(prices, opts \\ []), do: prices |> volatility(opts) |> unwrap!()
+
+  @doc """
+  Compound annual growth rate — the constant yearly rate that grows `begin_value`
+  into `end_value` over `years`.
+
+      (end_value / begin_value)^(1/years) − 1
+
+  Returns `{:error, :undefined}` when `begin_value` or `years` isn't positive, or
+  the two values have opposite signs (no real rate).
+
+      iex> Finance.Returns.cagr(1000, 2000, 10)
+      {:ok, 0.071773}
+  """
+  @spec cagr(number, number, number, keyword) :: {:ok, float} | {:error, error}
+  def cagr(begin_value, end_value, years, opts \\ [])
+      when is_number(begin_value) and is_number(end_value) and is_number(years) and is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @precision_options_schema)
+
+    cond do
+      begin_value <= 0 -> {:error, :undefined}
+      years <= 0 -> {:error, :undefined}
+      end_value / begin_value < 0 -> {:error, :undefined}
+      true -> {:ok, round_value(:math.pow(end_value / begin_value, 1 / years) - 1, opts)}
+    end
+  end
+
+  @doc "Same as `cagr/4`, but returns the value directly and raises `ArgumentError` on error."
+  @spec cagr!(number, number, number, keyword) :: float
+  def cagr!(begin_value, end_value, years, opts \\ []) do
+    begin_value |> cagr(end_value, years, opts) |> unwrap!()
+  end
+
+  @doc """
+  Payback period — how many periods of cash flow it takes to recover the initial
+  outlay, interpolating within the recovering period. The first amount is the
+  outlay (negative), the rest are inflows.
+
+  Returns `{:error, :undefined}` if the flows never recover, or there's no outlay
+  to recover, and `{:error, :insufficient_data}` for an empty list.
+
+      iex> Finance.Returns.payback_period([-1000, 400, 400, 400])
+      {:ok, 2.5}
+  """
+  @spec payback_period([number], keyword) :: {:ok, float} | {:error, error}
+  def payback_period(cash_flows, opts \\ []) when is_list(cash_flows) and is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @precision_options_schema)
+    recovery_result(cash_flows, opts)
+  end
+
+  @doc "Same as `payback_period/2`, but returns the value directly and raises `ArgumentError` on error."
+  @spec payback_period!([number], keyword) :: float
+  def payback_period!(cash_flows, opts \\ []), do: cash_flows |> payback_period(opts) |> unwrap!()
+
+  @doc """
+  Discounted payback period — like `payback_period/2`, but recovers the outlay
+  from cash flows discounted at `rate` (so it accounts for the time value of
+  money and is always at least as long as the plain payback).
+
+      iex> Finance.Returns.discounted_payback_period([-1000, 600, 600, 600], 0.1)
+      {:ok, 1.916667}
+  """
+  @spec discounted_payback_period([number], number, keyword) :: {:ok, float} | {:error, error}
+  def discounted_payback_period(cash_flows, rate, opts \\ [])
+      when is_list(cash_flows) and is_number(rate) and is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @precision_options_schema)
+    recovery_result(discount_flows(cash_flows, rate), opts)
+  end
+
+  @doc "Same as `discounted_payback_period/3`, but returns the value directly and raises `ArgumentError` on error."
+  @spec discounted_payback_period!([number], number, keyword) :: float
+  def discounted_payback_period!(cash_flows, rate, opts \\ []) do
+    cash_flows |> discounted_payback_period(rate, opts) |> unwrap!()
+  end
+
+  @doc """
+  Profitability index — the present value of a project's future inflows per unit
+  of initial investment, discounted at `rate`. A value above 1 means the project
+  adds value. Equivalent to `1 + NPV / initial investment`.
+
+  The first amount is the initial outlay (negative); returns `{:error, :undefined}`
+  if it isn't, and `{:error, :insufficient_data}` for an empty list.
+
+      iex> Finance.Returns.profitability_index([-1000, 600, 600], 0.1)
+      {:ok, 1.041322}
+  """
+  @spec profitability_index([number], number, keyword) :: {:ok, float} | {:error, error}
+  def profitability_index(cash_flows, rate, opts \\ [])
+      when is_list(cash_flows) and is_number(rate) and is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @precision_options_schema)
+    profitability(cash_flows, rate, opts)
+  end
+
+  @doc "Same as `profitability_index/3`, but returns the value directly and raises `ArgumentError` on error."
+  @spec profitability_index!([number], number, keyword) :: float
+  def profitability_index!(cash_flows, rate, opts \\ []) do
+    cash_flows |> profitability_index(rate, opts) |> unwrap!()
+  end
+
+  @doc """
+  Time-weighted return — the return of a series of period returns linked
+  geometrically, `∏(1 + rᵢ) − 1`. Immune to the timing of cash flows, which is
+  what makes it the standard way to measure manager or fund performance.
+
+  By default it's the cumulative return over the periods given. Pass
+  `:periods_per_year` to annualise it.
+
+      iex> Finance.Returns.twr([0.10, -0.05, 0.08])
+      {:ok, 0.1286}
+
+      iex> Finance.Returns.twr([0.02, 0.02], periods_per_year: 4)
+      {:ok, 0.082432}
+  """
+  @spec twr([number], keyword) :: {:ok, float} | {:error, error}
+  def twr(period_returns, opts \\ []) when is_list(period_returns) and is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @twr_options_schema)
+
+    cond do
+      period_returns == [] -> {:error, :insufficient_data}
+      not Enum.all?(period_returns, &is_number/1) -> {:error, :undefined}
+      true -> {:ok, round_value(time_weighted(period_returns, opts), opts)}
+    end
+  end
+
+  @doc "Same as `twr/2`, but returns the value directly and raises `ArgumentError` on error."
+  @spec twr!([number], keyword) :: float
+  def twr!(period_returns, opts \\ []), do: period_returns |> twr(opts) |> unwrap!()
 
   # Consecutive-pair returns, or :error if a price is non-positive. Order does
   # not matter for the standard deviation, so the reversed list is fine.
@@ -89,5 +242,74 @@ defmodule Finance.Returns do
     mean = Enum.sum(returns) / n
     sum_of_squares = Enum.reduce(returns, 0.0, fn r, acc -> acc + (r - mean) * (r - mean) end)
     :math.sqrt(sum_of_squares / (n - 1)) * :math.sqrt(periods_per_year)
+  end
+
+  # --- payback / discounted payback ---------------------------------------
+
+  defp recovery_result(flows, opts) do
+    case cumulative_recovery(flows) do
+      :empty ->
+        {:error, :insufficient_data}
+
+      :never ->
+        {:error, :undefined}
+
+      {:recovered, whole, shortfall, recovering_flow} ->
+        {:ok, round_value(whole + shortfall / recovering_flow, opts)}
+    end
+  end
+
+  # Find the first period where the running cumulative crosses from negative to
+  # non-negative, returning the whole periods before it, the shortfall still to
+  # recover, and the flow that recovers it. `:never` if it never crosses (or
+  # there's no initial outlay), `:empty` for no flows.
+  defp cumulative_recovery([]), do: :empty
+
+  defp cumulative_recovery(flows) do
+    flows
+    |> Enum.with_index()
+    |> Enum.reduce_while(0.0, fn {flow, i}, cumulative ->
+      next = cumulative + flow
+
+      if i > 0 and cumulative < 0 and next >= 0 do
+        {:halt, {:recovered, i - 1, -cumulative, flow}}
+      else
+        {:cont, next}
+      end
+    end)
+    |> then(fn
+      {:recovered, _, _, _} = recovered -> recovered
+      _cumulative -> :never
+    end)
+  end
+
+  defp discount_flows(flows, rate) do
+    flows
+    |> Enum.with_index()
+    |> Enum.map(fn {flow, i} -> flow / :math.pow(1 + rate, i) end)
+  end
+
+  # --- profitability index ------------------------------------------------
+
+  defp profitability([], _rate, _opts), do: {:error, :insufficient_data}
+  defp profitability([initial | _], _rate, _opts) when initial >= 0, do: {:error, :undefined}
+
+  defp profitability(cash_flows, rate, opts) do
+    precision = Keyword.fetch!(opts, :precision)
+
+    with {:ok, npv} <- Finance.CashFlow.npv(rate, cash_flows, precision: precision) do
+      {:ok, round_value(1 + npv / -hd(cash_flows), opts)}
+    end
+  end
+
+  # --- time-weighted return -----------------------------------------------
+
+  defp time_weighted(returns, opts) do
+    cumulative = Enum.reduce(returns, 1.0, fn r, acc -> acc * (1 + r) end) - 1
+
+    case Keyword.get(opts, :periods_per_year) do
+      nil -> cumulative
+      periods_per_year -> :math.pow(1 + cumulative, periods_per_year / length(returns)) - 1
+    end
   end
 end

--- a/lib/finance/tvm.ex
+++ b/lib/finance/tvm.ex
@@ -65,7 +65,7 @@ defmodule Finance.TVM do
     {:ok, value * 1.0}
   end
 
-  @doc "Same as `fv/5`, but hands back the value on its own and raises `ArgumentError` if the calculation fails."
+  @doc "Same as `fv/5`, but returns the value directly and raises `ArgumentError` on error."
   @spec fv!(number, number, number, number, 0 | 1) :: float
   def fv!(rate, nper, pmt, pv \\ 0.0, type \\ 0), do: rate |> fv(nper, pmt, pv, type) |> unwrap!()
 
@@ -94,7 +94,7 @@ defmodule Finance.TVM do
     {:ok, value * 1.0}
   end
 
-  @doc "Same as `pv/5`, but hands back the value on its own and raises `ArgumentError` if the calculation fails."
+  @doc "Same as `pv/5`, but returns the value directly and raises `ArgumentError` on error."
   @spec pv!(number, number, number, number, 0 | 1) :: float
   def pv!(rate, nper, pmt, fv \\ 0.0, type \\ 0), do: rate |> pv(nper, pmt, fv, type) |> unwrap!()
 
@@ -122,7 +122,7 @@ defmodule Finance.TVM do
     end
   end
 
-  @doc "Same as `pmt/5`, but hands back the value on its own and raises `ArgumentError` if the calculation fails."
+  @doc "Same as `pmt/5`, but returns the value directly and raises `ArgumentError` on error."
   @spec pmt!(number, number, number, number, 0 | 1) :: float
   def pmt!(rate, nper, pv, fv \\ 0.0, type \\ 0), do: rate |> pmt(nper, pv, fv, type) |> unwrap!()
 
@@ -146,7 +146,7 @@ defmodule Finance.TVM do
     end
   end
 
-  @doc "Same as `ipmt/6`, but hands back the value on its own and raises `ArgumentError` if the calculation fails."
+  @doc "Same as `ipmt/6`, but returns the value directly and raises `ArgumentError` on error."
   @spec ipmt!(number, number, number, number, number, 0 | 1) :: float
   def ipmt!(rate, per, nper, pv, fv \\ 0.0, type \\ 0) do
     rate |> ipmt(per, nper, pv, fv, type) |> unwrap!()
@@ -172,7 +172,7 @@ defmodule Finance.TVM do
     end
   end
 
-  @doc "Same as `ppmt/6`, but hands back the value on its own and raises `ArgumentError` if the calculation fails."
+  @doc "Same as `ppmt/6`, but returns the value directly and raises `ArgumentError` on error."
   @spec ppmt!(number, number, number, number, number, 0 | 1) :: float
   def ppmt!(rate, per, nper, pv, fv \\ 0.0, type \\ 0) do
     rate |> ppmt(per, nper, pv, fv, type) |> unwrap!()
@@ -338,7 +338,7 @@ defmodule Finance.TVM do
     end
   end
 
-  @doc "Same as `nper/5`, but hands back the value on its own and raises `ArgumentError` if the calculation fails."
+  @doc "Same as `nper/5`, but returns the value directly and raises `ArgumentError` on error."
   @spec nper!(number, number, number, number, 0 | 1) :: float
   def nper!(rate, pmt, pv, fv \\ 0.0, type \\ 0), do: rate |> nper(pmt, pv, fv, type) |> unwrap!()
 
@@ -368,7 +368,7 @@ defmodule Finance.TVM do
     end
   end
 
-  @doc "Same as `rate/6`, but hands back the rate on its own and raises `ArgumentError` if the calculation fails."
+  @doc "Same as `rate/6`, but returns the rate directly and raises `ArgumentError` on error."
   @spec rate!(number, number, number, number, 0 | 1, [option]) :: rate
   def rate!(nper, pmt, pv, fv \\ 0.0, type \\ 0, opts \\ []) do
     nper |> rate(pmt, pv, fv, type, opts) |> unwrap!()

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Finance.MixProject do
   use Mix.Project
 
-  @version "1.3.0"
+  @version "1.4.0"
   @source_url "https://github.com/tubedude/finance-elixir"
 
   def project do

--- a/test/finance_test.exs
+++ b/test/finance_test.exs
@@ -514,6 +514,65 @@ defmodule FinanceTest do
     end
   end
 
+  describe "Finance.Returns metrics" do
+    test "cagr" do
+      assert Finance.Returns.cagr(1000, 2000, 10) == {:ok, 0.071773}
+      assert Finance.Returns.cagr(1000, 1000, 5) == {:ok, 0.0}
+      assert Finance.Returns.cagr(-1000, 2000, 10) == {:error, :undefined}
+      assert Finance.Returns.cagr(1000, 2000, 0) == {:error, :undefined}
+      assert Finance.Returns.cagr(1000, -2000, 10) == {:error, :undefined}
+      assert Finance.Returns.cagr!(1000, 2000, 10) == 0.071773
+      assert_raise ArgumentError, fn -> Finance.Returns.cagr!(1000, 2000, 0) end
+    end
+
+    test "payback_period interpolates and reports undefined/empty" do
+      assert Finance.Returns.payback_period([-1000, 500, 500, 500]) == {:ok, 2.0}
+      assert Finance.Returns.payback_period([-1000, 400, 400, 400]) == {:ok, 2.5}
+      assert Finance.Returns.payback_period([-1000, 100, 100]) == {:error, :undefined}
+      assert Finance.Returns.payback_period([1000, 400]) == {:error, :undefined}
+      assert Finance.Returns.payback_period([]) == {:error, :insufficient_data}
+      assert Finance.Returns.payback_period!([-1000, 400, 400, 400]) == 2.5
+    end
+
+    test "discounted_payback_period" do
+      assert Finance.Returns.discounted_payback_period([-1000, 600, 600, 600], 0.1) ==
+               {:ok, 1.916667}
+
+      # at rate 0 it matches the plain payback
+      assert Finance.Returns.discounted_payback_period([-1000, 600, 600, 600], 0.0) ==
+               Finance.Returns.payback_period([-1000, 600, 600, 600])
+
+      assert Finance.Returns.discounted_payback_period([-1000, 100, 100], 0.1) ==
+               {:error, :undefined}
+
+      assert Finance.Returns.discounted_payback_period!([-1000, 600, 600, 600], 0.1) == 1.916667
+    end
+
+    test "profitability_index reuses npv" do
+      assert Finance.Returns.profitability_index([-1000, 600, 600], 0.1) == {:ok, 1.041322}
+      assert Finance.Returns.profitability_index([-1000, 1100], 0.1) == {:ok, 1.0}
+      assert Finance.Returns.profitability_index([1000, 600], 0.1) == {:error, :undefined}
+      assert Finance.Returns.profitability_index([], 0.1) == {:error, :insufficient_data}
+      assert Finance.Returns.profitability_index!([-1000, 600, 600], 0.1) == 1.041322
+    end
+
+    test "twr links returns geometrically, optionally annualised" do
+      assert Finance.Returns.twr([0.10, -0.05, 0.08]) == {:ok, 0.1286}
+      assert Finance.Returns.twr([0.0, 0.0]) == {:ok, 0.0}
+      assert Finance.Returns.twr([0.02, 0.02], periods_per_year: 4) == {:ok, 0.082432}
+      assert Finance.Returns.twr([]) == {:error, :insufficient_data}
+      assert Finance.Returns.twr([0.1, "x"]) == {:error, :undefined}
+      assert Finance.Returns.twr!([0.10, -0.05, 0.08]) == 0.1286
+      assert_raise ArgumentError, fn -> Finance.Returns.twr!([]) end
+    end
+
+    test "an unknown option raises" do
+      assert_raise NimbleOptions.ValidationError, fn ->
+        Finance.Returns.cagr(1000, 2000, 10, precison: 2)
+      end
+    end
+  end
+
   describe "volatility" do
     test "annualises the standard deviation of simple returns" do
       assert Finance.Returns.volatility([100, 102, 101, 103, 105]) == {:ok, 0.234528}


### PR DESCRIPTION
Phase 4 of the roadmap — fills out `Finance.Returns` beyond `volatility`.

## New
- **`cagr/4`** — compound annual growth rate.
- **`payback_period/2`** and **`discounted_payback_period/3`** — periods to recover the initial outlay, interpolated within the recovering period (fractional). Both share one `cumulative_recovery/1` helper; the discounted variant discounts each flow once (same factor `npv` uses).
- **`profitability_index/3`** — `1 + NPV / initial investment`, reusing `Finance.CashFlow.npv`.
- **`twr/2`** — time-weighted return (geometric linking), with an optional `:periods_per_year` to annualise.
- Bang variants for all five.

New functions, so module-only (no deprecated `Finance.*` delegators), consistent with `Finance.Bonds`.

## Quality
189 tests (45 doctests, 5 properties, 139 unit), `credo --strict`, dialyzer (0 errors), `mix format`, **100% coverage**, 0 doc warnings. Every value anchored to a computed figure (par CAGR, payback 2.0/2.5, PI 1.041322, TWR 0.1286). Version → `1.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)