### PR TITLE
Fix solver convergence for long-maturity, low-rate flows (1.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.4.1 — 2026-07-05
+
+### Fixed
+- The solver now converges for long-maturity, low-rate flows — for example the
+  `ytm` of a deep-discount 28-year bond, or a 30-year monthly amortization
+  `rate`. Previously a Newton step could overflow on such flows and abort the
+  whole solve instead of falling through to bisection, and the bisection bracket
+  itself overflowed for long-dated flows. Now a Newton overflow falls through to
+  bisection, the bracket floor adapts to the longest flow, and the bracketing
+  sign check compares signs instead of multiplying (which could overflow).
+
 ## 1.4.0 — 2026-07-04
 
 ### Added

--- a/lib/finance/solver/newton.ex
+++ b/lib/finance/solver/newton.ex
@@ -15,17 +15,23 @@ defmodule Finance.Solver.Newton do
     tolerance = Keyword.fetch!(opts, :tolerance)
     max_iterations = Keyword.fetch!(opts, :max_iterations)
 
-    # Each step returns `{:ok, rate}` or `:diverged`. `with` threads the
-    # "keep trying" case: on `:diverged` from Newton we fall through to
-    # bisection, and any `{:ok, rate}` drops to `else` to be rounded.
-    with :diverged <- newton(flows, guess, max_iterations, tolerance),
-         :diverged <- bisect(flows, max_iterations, tolerance) do
+    # Each stage returns `{:ok, rate}` or `:diverged`. `safely/1` turns an
+    # arithmetic overflow — which can happen at extreme rates on long-dated
+    # flows — into `:diverged`, so a Newton failure still falls through to
+    # bisection rather than aborting the whole solve. Any `{:ok, rate}` drops
+    # to `else` to be rounded.
+    with :diverged <- safely(fn -> newton(flows, guess, max_iterations, tolerance) end),
+         :diverged <- safely(fn -> bisect(flows, max_iterations, tolerance) end) do
       {:error, :did_not_converge}
     else
       {:ok, rate} -> {:ok, Float.round(rate, Keyword.fetch!(opts, :precision))}
     end
+  end
+
+  defp safely(fun) do
+    fun.()
   rescue
-    ArithmeticError -> {:error, :did_not_converge}
+    ArithmeticError -> :diverged
   end
 
   defp newton(_flows, _rate, 0, _tol), do: :diverged
@@ -51,7 +57,7 @@ defmodule Finance.Solver.Newton do
   end
 
   defp bisect(flows, max_iterations, tol) do
-    low = -0.999999
+    low = safe_low(flows)
 
     case bracket(flows, low, present_value(flows, low), 1.0) do
       {:ok, low, high} -> {:ok, bisection(flows, low, high, max_iterations, tol)}
@@ -59,11 +65,20 @@ defmodule Finance.Solver.Newton do
     end
   end
 
+  # The bracket's floor. As `rate` nears -1, `(1 + rate)^t` underflows to zero
+  # (then divides by zero) for large `t`, so raise the floor just enough that the
+  # longest-dated flow's discount factor stays finite. For short-dated flows this
+  # is the familiar `-0.999999`; for a 30-year monthly schedule it sits higher.
+  defp safe_low(flows) do
+    max_t = Enum.reduce(flows, 1.0, fn {t, _amount}, acc -> max(t, acc) end)
+    max(:math.pow(1.0e-290, 1 / max_t), 1.0e-6) - 1.0
+  end
+
   # Expand the upper bound until the NPV changes sign, giving us a bracket.
   defp bracket(_flows, _low, _f_low, high) when high > 1.0e7, do: :diverged
 
   defp bracket(flows, low, f_low, high) do
-    if f_low * present_value(flows, high) <= 0 do
+    if straddles_zero?(f_low, present_value(flows, high)) do
       {:ok, low, high}
     else
       bracket(flows, low, f_low, high * 2 + 1)
@@ -77,11 +92,21 @@ defmodule Finance.Solver.Newton do
     f_mid = present_value(flows, mid)
 
     cond do
-      abs(f_mid) < tol or high - low < tol -> mid
-      present_value(flows, low) * f_mid < 0 -> bisection(flows, low, mid, iterations - 1, tol)
-      true -> bisection(flows, mid, high, iterations - 1, tol)
+      abs(f_mid) < tol or high - low < tol ->
+        mid
+
+      straddles_zero?(present_value(flows, low), f_mid) ->
+        bisection(flows, low, mid, iterations - 1, tol)
+
+      true ->
+        bisection(flows, mid, high, iterations - 1, tol)
     end
   end
+
+  # Whether `a` and `b` sit on opposite sides of zero (a root lies between them).
+  # Comparing signs rather than the product `a * b` avoids overflow when the NPV
+  # is astronomically large near the bracket's floor for long-dated flows.
+  defp straddles_zero?(a, b), do: (a <= 0 and b >= 0) or (a >= 0 and b <= 0)
 
   # Derivative of the NPV with respect to rate: Σ -t · amount / (1 + rate)^(t+1)
   defp present_value_derivative(flows, rate) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Finance.MixProject do
   use Mix.Project
 
-  @version "1.4.0"
+  @version "1.4.1"
   @source_url "https://github.com/tubedude/finance-elixir"
 
   def project do

--- a/test/finance_test.exs
+++ b/test/finance_test.exs
@@ -685,6 +685,19 @@ defmodule FinanceTest do
       assert Finance.Bonds.ytm(100, 0.05, -50.0, 10) == {:error, :did_not_converge}
     end
 
+    test "ytm converges for long-maturity, low-yield bonds (solver overflow fallback)" do
+      # Newton overshoots into an overflow on these long-dated flows; the solver
+      # must fall through to bisection rather than give up. Regression for a
+      # deep-discount 28-year semiannual bond and a 30-year monthly bond.
+      {:ok, price} = Finance.Bonds.price(1000, 0.0097, 0.0233, 28)
+      assert {:ok, recovered} = Finance.Bonds.ytm(1000, 0.0097, price, 28)
+      assert_in_delta recovered, 0.0233, 1.0e-4
+
+      {:ok, monthly} = Finance.Bonds.price(1000, 0.01, 0.02, 30, 12)
+      assert {:ok, monthly_yield} = Finance.Bonds.ytm(1000, 0.01, monthly, 30, 12)
+      assert_in_delta monthly_yield, 0.02, 1.0e-3
+    end
+
     test "bang variants return bare values and raise on error" do
       assert Finance.Bonds.price!(100, 0.05, 0.05, 10) == 100.0
       assert Finance.Bonds.ytm!(100, 0.05, 100.0, 10) == 0.05


### PR DESCRIPTION
CI caught a **flaky bond `ytm` property**: the solver returned `:did_not_converge` for deep-discount, long-dated bonds (reproduced: `ytm(1000, 0.0097, 721.44, 28)`). Root cause was three numerical issues in `Finance.Solver.Newton`:

1. A Newton step that **overflowed** on long-dated flows raised `ArithmeticError`, which the `solve/2` rescue turned into `:did_not_converge` **without trying bisection**. Now each stage runs through `safely/1`, so a Newton overflow falls through to bisection.
2. The bisection bracket floor `-0.999999` made `present_value` **underflow → divide-by-zero** for long-dated flows. `safe_low/1` raises the floor just enough to keep the longest flow's discount factor finite (still `-0.999999` for short flows).
3. The bracketing sign check multiplied two NPVs (`f_low * f_mid`), which **overflows** when the NPV is astronomically large near the floor. `straddles_zero?/2` compares signs instead.

## Verification
- 20k random bonds (freq 1/2/4/12, up to 480 periods): **0 failures**.
- Full suite across seeds (including the `426686` seed that failed CI): green.
- Added a deterministic regression test for the overflow → bisection fallback.
- 190 tests, `credo --strict`, dialyzer (0 errors), `mix format`, **100% coverage**, 0 doc warnings. Patch release → `1.4.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)