### PR TITLE
Point the Hex Docs badge at 1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/tubedude/finance-elixir/actions/workflows/ci.yml/badge.svg)](https://github.com/tubedude/finance-elixir/actions/workflows/ci.yml)
 [![Hex.pm](https://img.shields.io/hexpm/v/finance.svg)](https://hex.pm/packages/finance)
-[![Hex Docs](https://img.shields.io/badge/hex-docs-8e5ea2.svg)](https://hexdocs.pm/finance)
+[![Hex Docs](https://img.shields.io/badge/hexdocs-1.4.1-8e5ea2.svg)](https://hexdocs.pm/finance/1.4.1)
 
 An Elixir library for cash-flow analysis. It covers internal rate of return
 (`xirr`/`irr`), net present value (`xnpv`/`npv`), and modified IRR (`mirr`),


### PR DESCRIPTION
Updates the Hex Docs badge to show and link `1.4.1` (`hexdocs.pm/finance/1.4.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)