### PR TITLE
Safeguarded Newton (rtsafe) as the default solver (1.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 1.4.2 — 2026-07-05
+
+### Fixed
+- The rate solver no longer reports a non-root as converged. Newton's step-size
+  termination could accept a rate where the NPV was still large — near a steep
+  NPV the step `f / f'` shrinks below the tolerance even while `f` does not — so
+  convergence now rests solely on the NPV threshold, and a stalled Newton falls
+  through to bisection.
+- `amortization_schedule` keeps the balance retiring monotonically within
+  `[0, opening]`. Once `(1 + rate)^nper` is large a cent-rounded level payment
+  can no longer tame the balance: rounded a hair high it overshot below zero,
+  a hair low it grew the balance back (negative amortization) before the final
+  row absorbed the difference. Each period now clamps so the schedule stays
+  monotonic and bounded, with a final row that clears whatever remains.
+
+### Added
+- Property-based stress tests for the solver and TVM: IRR root-finding across
+  extreme rates and long horizons, a no-crash / real-root contract on arbitrary
+  cash-flow signs, `TVM.rate` round-trips, `pv`/`fv` inversion, and amortization
+  balance invariants. These surfaced the two fixes above.
+
 ## 1.4.1 — 2026-07-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.4.3 — 2026-07-05
+
+### Changed
+- The default solver is now a safeguarded Newton (the classic `rtsafe`): it
+  brackets the root, then each step takes a Newton step when that step lands
+  inside the bracket and is converging fast enough, and a bisection step
+  otherwise — all in one pass, rather than running Newton to exhaustion and then
+  bisecting separately. Results are unchanged, but long-horizon flows are much
+  faster (a 480-period loan's `rate` solves ~9× quicker), and because the
+  maintained bracket always encloses a sign change the solver can no longer
+  return a stalled non-root. The bracket-membership test compares the Newton
+  point against the bracket instead of multiplying two net present values, which
+  would overflow in the steep zone near the bracket's floor for long-dated flows.
+
 ## 1.4.2 — 2026-07-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -118,6 +118,31 @@ When the data can't produce a result, `xirr/1` and `xirr/2` return
 | `:invalid_date`        | a date could not be parsed                       |
 | `:did_not_converge`    | no rate found within the iteration limit         |
 
+## Solver
+
+The rate functions (`irr`, `xirr`, `rate`, `ytm`) find their rate with a
+safeguarded Newton-Raphson — the classic `rtsafe`. It brackets the root, then
+each step is a Newton step when that step lands inside the bracket and is
+converging fast enough, and a bisection step otherwise. This keeps Newton's
+speed on ordinary flows and bisection's guaranteed convergence on awkward ones,
+in a single pass. Because the maintained bracket always encloses a sign change,
+the result is a genuine root rather than a stalled non-root. The solver is
+swappable via the `:solver` option or `config :finance, solver: MySolver`.
+
+`bench/solver_strategies.exs` compares it against the alternatives across flow
+sets of growing length (NPV/derivative evaluations per solve, and median time):
+
+| flow set        | safeguarded Newton | plain Newton, then bisect | pure bisection    |
+| --------------- | ------------------ | ------------------------- | ----------------- |
+| 4 flows         | 13 evals · 6.0 µs  | 8 evals · 3.9 µs          | 65 evals · 22 µs  |
+| 60-period loan  | 13 evals · 74 µs   | 44 evals · 277 µs         | 65 evals · 300 µs |
+| 480-period loan | 31 evals · 1.5 ms  | 265 evals · 13.5 ms       | 65 evals · 3.1 ms |
+
+Plain Newton edges ahead on short, well-behaved flows, but on long-horizon flows
+it burns its whole iteration budget before a separate bisection pass rescues it
+(~9× slower). Safeguarded Newton is the best all-rounder — fastest on the longer
+sets, close behind on the shortest. Run it with `mix run bench/solver_strategies.exs`.
+
 ## Development
 
 ```bash

--- a/bench/solver_strategies.exs
+++ b/bench/solver_strategies.exs
@@ -1,0 +1,247 @@
+# Benchmark: rate-solver strategies.
+#
+# The rate functions (irr/xirr/rate/ytm) find `r` where `Σ amount/(1+r)^t = 0`.
+# The shipped Finance.Solver.Newton runs Newton-Raphson first and falls back to
+# bracketing bisection when Newton leaves the domain or stalls. This compares
+# three strategies on identical flows:
+#
+#   * newton + bisect fallback — the shipped approach (Newton, then a *separate*
+#     bisection pass if Newton fails).
+#   * pure bisection           — robust but linearly convergent.
+#   * safeguarded newton       — Numerical Recipes' rtsafe: a Newton step when it
+#     stays inside a maintained bracket, a bisection step otherwise. Newton's
+#     speed and bisection's robustness folded into one pass.
+#
+# It reports both wall-clock time and the number of NPV / derivative evaluations
+# each strategy needs — the evaluation count is the mechanism behind the timings.
+#
+# Run with:  mix run bench/solver_strategies.exs
+
+defmodule Solvers do
+  @moduledoc false
+
+  # `pv/2` (NPV) and `dpv/2` (its derivative) are the unit of work every strategy
+  # shares. They bump a process-dictionary counter when `:evals` is set, so the
+  # analysis pass can tally evaluations; during timing `:evals` is unset and the
+  # bump is a single cheap dictionary read, identical for all three strategies.
+  defp count do
+    case Process.get(:evals) do
+      nil -> :ok
+      n -> Process.put(:evals, n + 1)
+    end
+  end
+
+  def pv(flows, rate) do
+    count()
+    Enum.reduce(flows, 0.0, fn {t, a}, acc -> acc + a / :math.pow(1 + rate, t) end)
+  end
+
+  def dpv(flows, rate) do
+    count()
+    Enum.reduce(flows, 0.0, fn {t, a}, acc -> acc + -t * a / :math.pow(1 + rate, t + 1) end)
+  end
+
+  # --- shared bracketing (identical to the shipped solver) ---
+  def safe_low(flows) do
+    max_t = Enum.reduce(flows, 1.0, fn {t, _a}, acc -> max(t, acc) end)
+    max(:math.pow(1.0e-290, 1 / max_t), 1.0e-6) - 1.0
+  end
+
+  defp straddles?(a, b), do: (a <= 0 and b >= 0) or (a >= 0 and b <= 0)
+
+  defp bracket(_flows, _low, _f_low, high) when high > 1.0e7, do: :diverged
+
+  defp bracket(flows, low, f_low, high) do
+    if straddles?(f_low, pv(flows, high)),
+      do: {:ok, low, high},
+      else: bracket(flows, low, f_low, high * 2 + 1)
+  end
+
+  # --- newton with a bisection fallback (mirrors Finance.Solver.Newton) ---
+  def newton(flows, opts) do
+    tol = opts[:tolerance]
+    max = opts[:max_iterations]
+
+    with :diverged <- nr(flows, opts[:guess], max, tol),
+         :diverged <- bisect(flows, max, tol) do
+      {:error, :did_not_converge}
+    else
+      {:ok, r} -> {:ok, Float.round(r, opts[:precision])}
+    end
+  end
+
+  defp nr(_flows, _rate, 0, _tol), do: :diverged
+
+  defp nr(flows, rate, iters, tol) do
+    f = pv(flows, rate)
+    df = dpv(flows, rate)
+
+    cond do
+      abs(f) < tol -> {:ok, rate}
+      df == 0.0 -> :diverged
+      true -> nr_step(flows, rate, rate - f / df, iters, tol)
+    end
+  end
+
+  defp nr_step(flows, rate, next, iters, tol) do
+    cond do
+      next <= -1.0 -> nr(flows, (rate - 1.0) / 2.0, iters - 1, tol)
+      abs(next - rate) < tol -> {:ok, next}
+      true -> nr(flows, next, iters - 1, tol)
+    end
+  end
+
+  # --- pure bisection ---
+  def bisect_solver(flows, opts) do
+    case bisect(flows, opts[:max_iterations], opts[:tolerance]) do
+      {:ok, r} -> {:ok, Float.round(r, opts[:precision])}
+      :diverged -> {:error, :did_not_converge}
+    end
+  end
+
+  defp bisect(flows, max, tol) do
+    low = safe_low(flows)
+
+    case bracket(flows, low, pv(flows, low), 1.0) do
+      {:ok, low, high} -> {:ok, bisection(flows, low, high, max, tol)}
+      :diverged -> :diverged
+    end
+  end
+
+  defp bisection(_flows, low, high, 0, _tol), do: (low + high) / 2
+
+  defp bisection(flows, low, high, iters, tol) do
+    mid = (low + high) / 2
+    f_mid = pv(flows, mid)
+
+    cond do
+      abs(f_mid) < tol or high - low < tol -> mid
+      straddles?(pv(flows, low), f_mid) -> bisection(flows, low, mid, iters - 1, tol)
+      true -> bisection(flows, mid, high, iters - 1, tol)
+    end
+  end
+
+  # --- safeguarded newton (rtsafe) ---
+  def safe(flows, opts) do
+    low = safe_low(flows)
+
+    case bracket(flows, low, pv(flows, low), 1.0) do
+      {:ok, a, b} ->
+        {xl, xh} = if pv(flows, a) < 0.0, do: {a, b}, else: {b, a}
+
+        root =
+          rtsafe(flows, (a + b) / 2, xl, xh, abs(b - a), opts[:tolerance], opts[:max_iterations])
+
+        {:ok, Float.round(root, opts[:precision])}
+
+      :diverged ->
+        {:error, :did_not_converge}
+    end
+  end
+
+  defp rtsafe(flows, rts, xl, xh, dxold, tol, iters) do
+    rtsafe(flows, rts, xl, xh, pv(flows, rts), dpv(flows, rts), dxold, tol, iters)
+  end
+
+  defp rtsafe(_flows, rts, _xl, _xh, _f, _df, _dxold, _tol, 0), do: rts
+
+  defp rtsafe(flows, rts, xl, xh, f, df, dxold, tol, iters) do
+    {rts2, dx} =
+      if bisection_step?(rts, xl, xh, f, df, dxold) do
+        d = (xh - xl) / 2.0
+        {xl + d, d}
+      else
+        d = f / df
+        {rts - d, d}
+      end
+
+    if abs(dx) < tol do
+      rts2
+    else
+      f2 = pv(flows, rts2)
+      df2 = dpv(flows, rts2)
+      {xl2, xh2} = if f2 < 0.0, do: {rts2, xh}, else: {xl, rts2}
+      rtsafe(flows, rts2, xl2, xh2, f2, df2, dx, tol, iters - 1)
+    end
+  end
+
+  # Take a bisection step (not Newton) when the derivative is flat, a Newton step
+  # would jump outside the bracket, or it isn't shrinking the interval fast enough.
+  defp bisection_step?(rts, xl, xh, f, df, dxold) do
+    df == 0.0 or
+      ((rts - xh) * df - f) * ((rts - xl) * df - f) > 0.0 or
+      abs(2.0 * f) > abs(dxold * df)
+  end
+end
+
+defmodule Fixtures do
+  @moduledoc false
+
+  # A fully-amortizing loan as normalized flows: +pv received at t=0, then `n`
+  # equal payments. One sign change, so a single real rate — well-conditioned.
+  def loan(pv, rate, n) do
+    pmt = pv * rate / (1 - :math.pow(1 + rate, -n))
+    [{0.0, pv * 1.0} | for(t <- 1..n, do: {t / 1.0, -pmt})]
+  end
+end
+
+opts = [guess: 0.1, tolerance: 1.0e-9, max_iterations: 100, precision: 6]
+
+inputs = %{
+  "easy — 4 flows, r≈9%" => [{0.0, -1000.0}, {1.0, 300.0}, {2.0, 400.0}, {3.0, 500.0}],
+  "medium — 60-period loan, r=1%/pd" => Fixtures.loan(100_000, 0.01, 60),
+  "long — 480-period loan, r=0.4%/pd" => Fixtures.loan(100_000, 0.004, 480)
+}
+
+strategies = [
+  {"newton + bisect fallback", &Solvers.newton/2},
+  {"pure bisection", &Solvers.bisect_solver/2},
+  {"safeguarded newton", &Solvers.safe/2}
+]
+
+# --- correctness: every strategy must agree, and the newton mirror must match
+# the shipped Finance.Solver.Newton exactly (so the timings below are credible) ---
+IO.puts("agreement — all strategies agree, and the mirror matches the shipped solver:\n")
+
+for {label, flows} <- inputs do
+  [n, b, s] = for {_name, solve} <- strategies, do: solve.(flows, opts)
+  shipped = Finance.Solver.Newton.solve(flows, opts)
+  ok = n == b and b == s and n == shipped
+
+  IO.puts(
+    "  #{String.pad_trailing(label, 34)} rate=#{elem(s, 1)}  mirror==shipped=#{n == shipped}  all_agree=#{ok}"
+  )
+end
+
+# --- analysis: NPV/derivative evaluations per solve ---
+IO.puts("\nNPV + derivative evaluations per solve (the mechanism behind the timings):\n")
+IO.puts("  #{String.pad_trailing("flow set", 34)}newton+bisect   pure bisect   safeguarded")
+
+for {label, flows} <- inputs do
+  [n, b, s] =
+    for {_name, solve} <- strategies do
+      Process.put(:evals, 0)
+      solve.(flows, opts)
+      Process.get(:evals)
+    end
+
+  Process.delete(:evals)
+
+  row =
+    [n, b, s]
+    |> Enum.map(&String.pad_leading(Integer.to_string(&1), 12))
+    |> Enum.join("  ")
+
+  IO.puts("  #{String.pad_trailing(label, 32)}#{row}")
+end
+
+# --- timing ---
+IO.puts("")
+
+Benchee.run(
+  Map.new(strategies, fn {name, solve} -> {name, fn flows -> solve.(flows, opts) end} end),
+  inputs: inputs,
+  time: 3,
+  memory_time: 1,
+  warmup: 1
+)

--- a/lib/finance/solver/newton.ex
+++ b/lib/finance/solver/newton.ex
@@ -48,11 +48,15 @@ defmodule Finance.Solver.Newton do
   end
 
   defp newton_step(flows, rate, next, iterations, tol) do
-    cond do
-      # A Newton step outside the (-1, ∞) domain: halve the distance to -1.
-      next <= -1.0 -> newton(flows, (rate - 1.0) / 2.0, iterations - 1, tol)
-      abs(next - rate) < tol -> {:ok, next}
-      true -> newton(flows, next, iterations - 1, tol)
+    # Convergence is decided only by `abs(f) < tol` at the top of `newton/4`, not
+    # by the step size: near a steep NPV the step `f / f'` can fall below `tol`
+    # while `f` itself is still large, which would otherwise report a non-root as
+    # solved. A stalled Newton instead exhausts its iterations and falls through
+    # to bisection. A step outside the (-1, ∞) domain halves the distance to -1.
+    if next <= -1.0 do
+      newton(flows, (rate - 1.0) / 2.0, iterations - 1, tol)
+    else
+      newton(flows, next, iterations - 1, tol)
     end
   end
 

--- a/lib/finance/solver/newton.ex
+++ b/lib/finance/solver/newton.ex
@@ -1,8 +1,17 @@
 defmodule Finance.Solver.Newton do
   @moduledoc """
-  The default `Finance.Solver`: Newton-Raphson using the analytic derivative of
-  the net present value, with a bracketing bisection fallback when a Newton step
-  wanders outside the `(-1, ∞)` domain or fails to converge.
+  The default `Finance.Solver`: a safeguarded Newton-Raphson (the classic
+  `rtsafe`).
+
+  It brackets the root first, then each iteration takes a Newton step when that
+  step lands inside the bracket and is shrinking the interval fast enough, and a
+  bisection step otherwise. This keeps Newton's quadratic speed on well-behaved
+  flows while retaining bisection's guaranteed convergence — in one pass, rather
+  than running Newton to exhaustion and then bisecting separately.
+
+  Because the maintained bracket always encloses a sign change, the result is a
+  genuine root rather than a stalled non-root, and a long-dated flow whose raw
+  Newton step would overflow simply takes a bisection step instead.
   """
 
   @behaviour Finance.Solver
@@ -15,59 +24,81 @@ defmodule Finance.Solver.Newton do
     tolerance = Keyword.fetch!(opts, :tolerance)
     max_iterations = Keyword.fetch!(opts, :max_iterations)
 
-    # Each stage returns `{:ok, rate}` or `:diverged`. `safely/1` turns an
-    # arithmetic overflow — which can happen at extreme rates on long-dated
-    # flows — into `:diverged`, so a Newton failure still falls through to
-    # bisection rather than aborting the whole solve. Any `{:ok, rate}` drops
-    # to `else` to be rounded.
-    with :diverged <- safely(fn -> newton(flows, guess, max_iterations, tolerance) end),
-         :diverged <- safely(fn -> bisect(flows, max_iterations, tolerance) end) do
-      {:error, :did_not_converge}
-    else
+    case safely(fn -> rtsafe(flows, guess, tolerance, max_iterations) end) do
       {:ok, rate} -> {:ok, Float.round(rate, Keyword.fetch!(opts, :precision))}
+      :diverged -> {:error, :did_not_converge}
     end
   end
 
+  # Arithmetic overflow at extreme rates on long-dated flows is treated as a
+  # failure to converge rather than crashing the solve.
   defp safely(fun) do
     fun.()
   rescue
     ArithmeticError -> :diverged
   end
 
-  defp newton(_flows, _rate, 0, _tol), do: :diverged
-
-  defp newton(flows, rate, iterations, tol) do
-    f = present_value(flows, rate)
-    derivative = present_value_derivative(flows, rate)
-
-    cond do
-      abs(f) < tol -> {:ok, rate}
-      derivative == 0.0 -> :diverged
-      true -> newton_step(flows, rate, rate - f / derivative, iterations, tol)
-    end
-  end
-
-  defp newton_step(flows, rate, next, iterations, tol) do
-    # Convergence is decided only by `abs(f) < tol` at the top of `newton/4`, not
-    # by the step size: near a steep NPV the step `f / f'` can fall below `tol`
-    # while `f` itself is still large, which would otherwise report a non-root as
-    # solved. A stalled Newton instead exhausts its iterations and falls through
-    # to bisection. A step outside the (-1, ∞) domain halves the distance to -1.
-    if next <= -1.0 do
-      newton(flows, (rate - 1.0) / 2.0, iterations - 1, tol)
-    else
-      newton(flows, next, iterations - 1, tol)
-    end
-  end
-
-  defp bisect(flows, max_iterations, tol) do
+  # Bracket a sign change, then run the safeguarded iteration from `guess` (when it
+  # falls inside the bracket) or the midpoint.
+  defp rtsafe(flows, guess, tol, max_iterations) do
     low = safe_low(flows)
 
     case bracket(flows, low, present_value(flows, low), 1.0) do
-      {:ok, low, high} -> {:ok, bisection(flows, low, high, max_iterations, tol)}
-      :diverged -> :diverged
+      {:ok, a, b} ->
+        bracket = orient(flows, a, b)
+        x = if guess > a and guess < b, do: guess, else: (a + b) / 2
+        f = present_value(flows, x)
+        df = present_value_derivative(flows, x)
+        {:ok, search(flows, x, bracket, f, df, abs(b - a), tol, max_iterations)}
+
+      :diverged ->
+        :diverged
     end
   end
+
+  # Orient the bracket so the net present value is negative at `xlo` and positive
+  # at `xhi` — the invariant the step selection and re-bracketing below rely on.
+  defp orient(flows, a, b) do
+    if present_value(flows, a) < 0.0, do: {a, b}, else: {b, a}
+  end
+
+  defp search(_flows, x, _bracket, _f, _df, _dxold, _tol, 0), do: x
+
+  defp search(flows, x, {xlo, xhi}, f, df, dxold, tol, iters) do
+    {next, dx} = move(x, xlo, xhi, f, df, dxold)
+
+    if abs(dx) < tol do
+      next
+    else
+      f_next = present_value(flows, next)
+      df_next = present_value_derivative(flows, next)
+      bracket = if f_next < 0.0, do: {next, xhi}, else: {xlo, next}
+      search(flows, next, bracket, f_next, df_next, dx, tol, iters - 1)
+    end
+  end
+
+  # A Newton step when it's usable, a bisection step otherwise. Returns
+  # `{next_x, step}`.
+  defp move(x, xlo, xhi, f, df, dxold) do
+    if newton_usable?(x, xlo, xhi, f, df, dxold) do
+      dx = f / df
+      {x - dx, dx}
+    else
+      dx = (xhi - xlo) / 2.0
+      {xlo + dx, dx}
+    end
+  end
+
+  # Prefer Newton when the derivative isn't flat, the step lands inside the
+  # bracket, and it shrinks the interval by at least half. Comparing the Newton
+  # point against the bracket — rather than the classic
+  # `((x-xhi)·df - f)·((x-xlo)·df - f)` product — avoids an overflow in the steep
+  # zone near the bracket's floor. `df != 0.0` short-circuits before `x - f / df`.
+  defp newton_usable?(x, xlo, xhi, f, df, dxold) do
+    df != 0.0 and inside?(x - f / df, xlo, xhi) and abs(2.0 * f) <= abs(dxold * df)
+  end
+
+  defp inside?(point, xlo, xhi), do: point >= min(xlo, xhi) and point <= max(xlo, xhi)
 
   # The bracket's floor. As `rate` nears -1, `(1 + rate)^t` underflows to zero
   # (then divides by zero) for large `t`, so raise the floor just enough that the
@@ -86,24 +117,6 @@ defmodule Finance.Solver.Newton do
       {:ok, low, high}
     else
       bracket(flows, low, f_low, high * 2 + 1)
-    end
-  end
-
-  defp bisection(_flows, low, high, 0, _tol), do: (low + high) / 2
-
-  defp bisection(flows, low, high, iterations, tol) do
-    mid = (low + high) / 2
-    f_mid = present_value(flows, mid)
-
-    cond do
-      abs(f_mid) < tol or high - low < tol ->
-        mid
-
-      straddles_zero?(present_value(flows, low), f_mid) ->
-        bisection(flows, low, mid, iterations - 1, tol)
-
-      true ->
-        bisection(flows, mid, high, iterations - 1, tol)
     end
   end
 

--- a/lib/finance/tvm.ex
+++ b/lib/finance/tvm.ex
@@ -277,14 +277,25 @@ defmodule Finance.TVM do
     {rows, _balance} =
       Enum.map_reduce(1..nper, opening, fn period, balance ->
         interest = round(-balance * rate)
-        principal = if period == nper, do: -balance, else: payment - interest
+        scheduled = if period == nper, do: -balance, else: payment - interest
+        # Keep the balance retiring toward zero within `[0, opening]`. Once
+        # `(1 + rate)^nper` is large, a cent-rounded level payment no longer tames
+        # the balance: rounded a hair high it overshoots below zero, a hair low it
+        # grows the balance back (negative amortization). Both are amplified period
+        # over period. Clamping keeps every schedule monotonic and bounded, with a
+        # final row that clears whatever remains.
+        principal = clamp_to_balance(scheduled, balance)
         new_balance = balance + principal
-        row_payment = if period == nper, do: interest + principal, else: payment
-        {{period, row_payment, interest, principal, new_balance}, new_balance}
+        {{period, interest + principal, interest, principal, new_balance}, new_balance}
       end)
 
     rows
   end
+
+  # Bound the principal to `[-balance, 0]`: never grow the balance (`min(_, 0)`)
+  # and never pay off more than is owed (`max(_, -balance)`), so it moves toward
+  # zero without overshooting. A normal amortizing payment already falls in range.
+  defp clamp_to_balance(scheduled, balance), do: scheduled |> max(-balance) |> min(0)
 
   defp row_to_float({period, payment, interest, principal, balance}, scale) do
     %{

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Finance.MixProject do
   use Mix.Project
 
-  @version "1.4.1"
+  @version "1.4.2"
   @source_url "https://github.com/tubedude/finance-elixir"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Finance.MixProject do
   use Mix.Project
 
-  @version "1.4.2"
+  @version "1.4.3"
   @source_url "https://github.com/tubedude/finance-elixir"
 
   def project do

--- a/test/finance_test.exs
+++ b/test/finance_test.exs
@@ -242,16 +242,37 @@ defmodule FinanceTest do
     end
   end
 
-  describe "solver bisection fallback" do
-    # `max_iterations: 1` starves Newton so it bails to the bisection fallback.
+  describe "solver bracketing" do
+    # A single safeguarded step still returns the bracketed estimate rather than
+    # erroring, so a starved solver yields a value when a root is bracketed.
     test "returns a value when a root is bracketed" do
       assert {:ok, _rate} = Finance.CashFlow.irr([-1000, 500, 500, 300], max_iterations: 1)
     end
 
     test "diverges when no root can be bracketed" do
-      # An all-positive series has no rate; bisection expands its bracket, then gives up.
+      # An all-positive series has no rate; the bracket expands, finds no sign
+      # change, and the solver gives up.
       assert Finance.TVM.rate(10, 100, 1000, 0.0, 0, max_iterations: 1) ==
                {:error, :did_not_converge}
+    end
+
+    test "a guess outside the bracket falls back to the midpoint and still converges" do
+      assert Finance.CashFlow.irr([-1000, 1100], guess: 5.0) == {:ok, 0.1}
+    end
+
+    test "magnitudes that overflow the discounting are reported, not raised" do
+      # Near the bracket floor, discounting a ~1e308 flow overflows; the solver
+      # treats that as a failure to converge rather than crashing the caller.
+      assert Finance.CashFlow.irr([1.0e308, -1.0e308]) == {:error, :did_not_converge}
+    end
+
+    test "converges on long-dated flows whose steep NPV would overflow a naive step" do
+      # A 471-period loan puts the bracket floor deep enough that the NPV near it
+      # is ~1e290; the safeguarded step must compare the Newton point against the
+      # bracket rather than multiply those magnitudes (which overflows).
+      {:ok, pv} = Finance.TVM.pv(0.011, 471, -1, 0.0, 0)
+      assert {:ok, rate} = Finance.TVM.rate(471, -1, pv, 0.0, 0, precision: 10)
+      assert_in_delta rate, 0.011, 1.0e-6
     end
   end
 

--- a/test/finance_test.exs
+++ b/test/finance_test.exs
@@ -781,6 +781,18 @@ defmodule FinanceTest do
       assert List.first(rows).interest == -8.3333
     end
 
+    test "an ill-conditioned rate never drives the balance negative" do
+      # 26.55%/period over 79 periods: `(1 + rate)^nper` is enormous, so the
+      # cent-rounded level payment overshoots. The balance must still march down
+      # to zero and stop there, never into money that isn't owed.
+      assert {:ok, rows} = Finance.TVM.amortization_schedule(0.2655, 79, 409_239)
+      balances = Enum.map(rows, & &1.balance)
+      assert Enum.all?(balances, &(&1 >= 0.0))
+      assert balances == Enum.sort(balances, :desc)
+      assert List.last(rows).balance == 0.0
+      assert_in_delta Enum.sum(Enum.map(rows, & &1.principal)), -409_239, 0.01
+    end
+
     test "at zero rate principal is spread evenly" do
       assert {:ok, rows} = Finance.TVM.amortization_schedule(0.0, 4, 1000)
       assert Enum.map(rows, & &1.principal) == [-250.0, -250.0, -250.0, -250.0]
@@ -904,5 +916,114 @@ defmodule FinanceTest do
         end
       end
     end
+  end
+
+  describe "solver and TVM stress properties" do
+    # Finance a stream of positive inflows so the outlay is exactly their present
+    # value at a known rate. That gives a single sign change (one real IRR) over
+    # rates and horizons extreme enough to stress the Newton/bisection solver, and
+    # we confirm the rate it returns drives the NPV back to ~zero.
+    property "irr finds a root that zeroes the NPV across extreme rates and long horizons" do
+      check all(
+              rate_bp <- integer(-9_000..80_000),
+              inflows <- list_of(integer(1..1_000_000), min_length: 1, max_length: 40)
+            ) do
+        rate = rate_bp / 10_000
+        outlay = present_value_at(rate, Enum.with_index(inflows, 1))
+        flows = [-outlay | inflows]
+
+        case Finance.CashFlow.irr(flows, precision: 12) do
+          {:ok, found} ->
+            npv = present_value_at(found, Enum.with_index(flows, 0))
+            assert_in_delta npv, 0.0, 1.0e-4 * (abs(outlay) + 1)
+
+          {:error, reason} ->
+            assert reason in [:did_not_converge, :single_signed_flow, :insufficient_data]
+        end
+      end
+    end
+
+    # The wild-edge-case contract: whatever signs the flows take — including the
+    # many-sign-change cases that admit several IRRs — the solver must never
+    # crash. It either returns a rate sitting on a genuine sign change of the NPV
+    # (a real root) or one of the documented errors.
+    property "irr never crashes on arbitrary flows; any rate it returns brackets a real root" do
+      check all(amounts <- list_of(integer(-1_000_000..1_000_000), max_length: 30)) do
+        case Finance.CashFlow.irr(amounts, precision: 10) do
+          {:ok, rate} ->
+            assert is_float(rate) and rate > -1.0
+            indexed = Enum.with_index(amounts, 0)
+            # Assert a zero-crossing rather than the NPV magnitude: a steep NPV is
+            # large even a hair from its root, whereas a spurious non-root shows
+            # no crossing at all. The window sits well inside the (-1, ∞) domain.
+            h = min(max(abs(rate), 1.0) * 1.0e-6, (1.0 + rate) / 2)
+            below = present_value_at(rate - h, indexed)
+            above = present_value_at(rate + h, indexed)
+            assert (below <= 0 and above >= 0) or (below >= 0 and above <= 0)
+
+          {:error, reason} ->
+            assert reason in [:insufficient_data, :single_signed_flow, :did_not_converge]
+        end
+      end
+    end
+
+    # Round-trip through the TVM solver: build a loan's present value from a known
+    # rate, then confirm `rate/6` recovers it — over terms up to 600 periods.
+    property "TVM.rate recovers the rate a loan was built at" do
+      check all(
+              rate_bp <- integer(1..5_000),
+              nper <- integer(2..600),
+              pmt <- integer(-1_000_000..-1)
+            ) do
+        rate = rate_bp / 10_000
+        assert {:ok, pv} = Finance.TVM.pv(rate, nper, pmt, 0.0, 0)
+        assert {:ok, found} = Finance.TVM.rate(nper, pmt, pv, 0.0, 0, precision: 10)
+        assert_in_delta found, rate, 1.0e-4
+      end
+    end
+
+    # `pv` and `fv` are inverse views of the same annuity, so composing them
+    # returns the value untouched.
+    property "pv and fv invert each other" do
+      check all(
+              rate_bp <- integer(0..50_000),
+              nper <- integer(1..240),
+              pmt <- integer(-1_000_000..1_000_000),
+              pv <- integer(-1_000_000..1_000_000)
+            ) do
+        rate = rate_bp / 10_000
+        assert {:ok, fv} = Finance.TVM.fv(rate, nper, pmt, pv, 0)
+        assert {:ok, back} = Finance.TVM.pv(rate, nper, pmt, fv, 0)
+        assert_in_delta back, pv, 1.0e-3 * (abs(pv) + abs(pmt) + 1)
+      end
+    end
+
+    # Whatever the rate, term, or size, the integer-minor-unit engine must retire
+    # the balance to exactly zero and have the principal portions sum to the loan.
+    property "the amortization schedule pays the balance down to exactly zero" do
+      check all(
+              rate_bp <- integer(0..3_000),
+              nper <- integer(1..360),
+              pv <- integer(100..1_000_000)
+            ) do
+        rate = rate_bp / 10_000
+        assert {:ok, rows} = Finance.TVM.amortization_schedule(rate, nper, pv)
+        assert length(rows) == nper
+        assert List.last(rows).balance == 0.0
+        assert_in_delta Enum.sum(Enum.map(rows, & &1.principal)), -pv, 1.0e-6 * pv + 0.01
+        balances = Enum.map(rows, & &1.balance)
+        # Monotonically non-increasing, and it never overshoots into a balance you
+        # don't owe — even when a cent-rounded payment is amplified over the term.
+        assert balances == Enum.sort(balances, :desc)
+        assert Enum.all?(balances, &(&1 >= 0.0))
+      end
+    end
+  end
+
+  # Present value of `{amount, period}` pairs at `rate`: Σ amount / (1 + rate)^period.
+  defp present_value_at(rate, indexed_flows) do
+    Enum.reduce(indexed_flows, 0.0, fn {amount, t}, acc ->
+      acc + amount / :math.pow(1 + rate, t)
+    end)
   end
 end


### PR DESCRIPTION
Implements the benchmark's conclusion: replace the two-pass **Newton-then-separate-bisection** solver with a **safeguarded Newton (rtsafe)** — bracket the root, then each step is a Newton step when it lands inside the bracket and is converging fast enough, and a bisection step otherwise, in **one pass**.

> **Stacks on #16 (1.4.2).** This branch is cut from `solver-tvm-property-tests`, so it carries #16's stress properties and amortization fix. Merge **#16 first**, then this; the diff here reduces to just the solver once #16 lands.

## Why
The [solver-strategy benchmark](../blob/solver-benchmark/bench/solver_strategies.exs) showed the old design is fastest *only* when Newton converges from the guess. On long-horizon flows Newton burns its whole 100-iteration budget before the separate bisection pass rescues it — **~8× slower** than a safeguarded pass (480-period loan: 265 evals vs 31).

## What changed
- `Finance.Solver.Newton` is now rtsafe. Same public contract, same rates (**all regression anchors hold**).
- A **480-period loan's `rate` solves ~9× faster** (≈1.5 ms vs ≈14 ms).
- The maintained bracket always encloses a sign change, so the solver **can't return a stalled non-root**, and a long-dated flow whose raw Newton step would overflow just takes a bisection step.
- The bracket-membership test compares the Newton point to the bracket instead of the classic `((x-xhi)·df − f)·((x-xlo)·df − f)` product — **that product overflows in the steep zone near the bracket floor** for long-dated flows. The 1.4.2 stress property (`TVM.rate` recovery) caught this during development.

## Verification
199 tests (45 doctests, 10 properties, 144 unit), **100% coverage** on the rewritten solver, `credo --strict`, dialyzer, `mix format`, 0 doc warnings. Green across a 16-seed sweep. New regression tests: the 471-period overflow case, a guess outside the bracket → midpoint fallback, and overflow magnitudes reported as `:did_not_converge`. Patch → `1.4.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)