### PR TITLE
Make the Hex Docs badge auto-track the latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/tubedude/finance-elixir/actions/workflows/ci.yml/badge.svg)](https://github.com/tubedude/finance-elixir/actions/workflows/ci.yml)
 [![Hex.pm](https://img.shields.io/hexpm/v/finance.svg)](https://hex.pm/packages/finance)
-[![Hex Docs](https://img.shields.io/badge/hexdocs-1.4.1-8e5ea2.svg)](https://hexdocs.pm/finance/1.4.1)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-8e5ea2.svg)](https://hexdocs.pm/finance)
 
 An Elixir library for cash-flow analysis. It covers internal rate of return
 (`xirr`/`irr`), net present value (`xnpv`/`npv`), and modified IRR (`mirr`),


### PR DESCRIPTION
The Hex Docs badge was pinned to a version (`1.4.1`) and went stale on each release. Point it at the unversioned `hexdocs.pm/finance` (always redirects to the newest docs) and drop the version from the label — the Hex.pm badge already carries the version number. No more manual bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)