### PR TITLE
Accept ex_money %Money{} amounts + single-currency check (1.5.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
             otp: "27"
           - elixir: "1.20"
             otp: "29"
+          # Exercise the lower bound of `decimal ~> 2.0 or ~> 3.0`.
+          - elixir: "1.20"
+            otp: "29"
+            decimal: "2"
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
@@ -26,7 +30,10 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-mix-${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}
+          key: ${{ runner.os }}-mix-${{ matrix.elixir }}-decimal${{ matrix.decimal || '3' }}-${{ hashFiles('mix.lock') }}
+      - name: Pin Decimal to 2.x
+        if: matrix.decimal == '2'
+        run: sed -i 's/~> 2.0 or ~> 3.0/~> 2.0/' mix.exs && mix deps.unlock decimal
       - run: mix deps.get
       - run: mix format --check-formatted
       - run: mix credo --strict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.5.1 — 2026-07-05
+
+### Added
+- Cash-flow amounts may now be `ex_money` `%Money{}` values, alongside numbers
+  and `Decimal`. Finance takes the `Decimal` amount without depending on ex_money,
+  and rejects a series that mixes currencies with `{:error, :mixed_currencies}`
+  (plain numbers and `Decimal` are currency-neutral and never conflict).
+
+### Changed
+- The optional `decimal` requirement is relaxed to `~> 2.0 or ~> 3.0`, so finance
+  can share a project with libraries pinned to Decimal 2.x — ex_money among them.
+
 ## 1.5.0 — 2026-07-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ One thing to watch: `npv/2` places the first amount at period 0, which is what
 makes `npv(irr(a), a) ≈ 0` hold. A spreadsheet `NPV` instead places the first
 amount at period 1, so the two won't agree unless you account for that.
 
-### Amounts and Decimal
+### Amounts: numbers, Decimal, and Money
 
 Amounts may be any number — integer minor units such as cents, or floats. If your
 app already depends on [`Decimal`](https://hex.pm/packages/decimal), you can pass
@@ -101,10 +101,24 @@ Finance.CashFlow.xirr([{~D[2019-01-01], Decimal.new("-1000")}, {~D[2020-01-01], 
 #=> {:ok, 0.1}
 ```
 
-`Decimal` is an optional dependency, so apps that don't use it pull in nothing
-extra. Either way the result comes back as a float: XIRR's math is inherently
-irrational, so accepting `Decimal` is about convenience at the call site, not
-added precision in the answer.
+[`ex_money`](https://hex.pm/packages/ex_money) `%Money{}` values work too — common
+when amounts come from an Ecto money column — and here the currency matters:
+
+```elixir
+Finance.CashFlow.xirr([{~D[2019-01-01], Money.new(:USD, "-1000")}, {~D[2020-01-01], Money.new(:USD, "1100")}])
+#=> {:ok, 0.1}
+
+# A series may not mix currencies:
+Finance.CashFlow.irr([Money.new(:USD, "-1000"), Money.new(:EUR, "1100")])
+#=> {:error, :mixed_currencies}
+```
+
+Both `Decimal` and `ex_money` are optional — apps that don't use them pull in
+nothing extra (finance reads a `%Money{}`'s amount without depending on it). Plain
+numbers and `Decimal` are currency-neutral, so they never trip the currency check.
+Either way the result comes back as a float: rate-of-return math is inherently
+irrational, so accepting these types is convenience at the call site, not added
+precision in the answer.
 
 ### Errors
 
@@ -118,6 +132,7 @@ When the data can't produce a result, `xirr/1` and `xirr/2` return
 | `:single_signed_flow`  | all amounts have the same sign                   |
 | `:invalid_date`        | a date could not be parsed                       |
 | `:did_not_converge`    | no rate found within the iteration limit         |
+| `:mixed_currencies`    | a series mixes two or more `%Money{}` currencies |
 
 ## Solver
 

--- a/lib/finance.ex
+++ b/lib/finance.ex
@@ -40,8 +40,11 @@ defmodule Finance do
   @typedoc "A date, given either as a `Date` struct or as an Erlang-style `{year, month, day}` tuple."
   @type date :: Date.t() | {integer, integer, integer}
 
-  @typedoc "A cash-flow amount: any number, or a `Decimal` when that optional dependency is installed."
-  @type amount :: number | Decimal.t()
+  @typedoc """
+  A cash-flow amount: a number, a `Decimal`, or an `ex_money` `%Money{}` (when
+  those optional libraries are installed). A single series may not mix currencies.
+  """
+  @type amount :: number | Decimal.t() | struct()
 
   @typedoc "A cash flow on a given date. Money coming in is positive, money going out is negative."
   @type cash_flow :: {date, amount}
@@ -65,6 +68,7 @@ defmodule Finance do
           | :invalid_date
           | :did_not_converge
           | :undefined
+          | :mixed_currencies
 
   # === Finance.CashFlow ====================================================
 

--- a/lib/finance/cash_flow.ex
+++ b/lib/finance/cash_flow.ex
@@ -28,7 +28,8 @@ defmodule Finance.CashFlow do
       unwrap!: 1,
       options: 1,
       resolve_solver: 1,
-      present_value: 2
+      present_value: 2,
+      check_currency: 1
     ]
 
   @type date :: Finance.date()
@@ -198,7 +199,7 @@ defmodule Finance.CashFlow do
     opts = options(opts)
     flows = periodic_flows(amounts)
 
-    with :ok <- validate(flows) do
+    with :ok <- check_currency(amounts), :ok <- validate(flows) do
       resolve_solver(opts).solve(flows, opts)
     end
   end
@@ -260,7 +261,10 @@ defmodule Finance.CashFlow do
   def npv(rate, amounts, opts)
       when is_number(rate) and is_list(amounts) and is_list(opts) do
     opts = options(opts)
-    {:ok, round_value(present_value(periodic_flows(amounts), rate), opts)}
+
+    with :ok <- check_currency(amounts) do
+      {:ok, round_value(present_value(periodic_flows(amounts), rate), opts)}
+    end
   end
 
   @doc "Same as `npv/2`, but returns the value directly and raises `ArgumentError` on error."
@@ -288,13 +292,16 @@ defmodule Finance.CashFlow do
       when is_list(amounts) and is_number(finance_rate) and is_number(reinvest_rate) and
              is_list(opts) do
     opts = options(opts)
-    values = Enum.map(amounts, &to_amount/1)
-    n = length(values)
 
-    cond do
-      n < 2 -> {:error, :insufficient_data}
-      not signed_both_ways?(values) -> {:error, :single_signed_flow}
-      true -> {:ok, round_value(modified_irr(values, finance_rate, reinvest_rate, n), opts)}
+    with :ok <- check_currency(amounts) do
+      values = Enum.map(amounts, &to_amount/1)
+      n = length(values)
+
+      cond do
+        n < 2 -> {:error, :insufficient_data}
+        not signed_both_ways?(values) -> {:error, :single_signed_flow}
+        true -> {:ok, round_value(modified_irr(values, finance_rate, reinvest_rate, n), opts)}
+      end
     end
   end
 
@@ -374,11 +381,13 @@ defmodule Finance.CashFlow do
   end
 
   defp prepare_periodic(amounts) when is_list(amounts) do
-    flows = periodic_flows(amounts)
+    with :ok <- check_currency(amounts) do
+      flows = periodic_flows(amounts)
 
-    case validate(flows) do
-      :ok -> {:ready, flows}
-      error -> error
+      case validate(flows) do
+        :ok -> {:ready, flows}
+        error -> error
+      end
     end
   end
 
@@ -387,18 +396,20 @@ defmodule Finance.CashFlow do
   defp normalize([]), do: {:error, :insufficient_data}
 
   defp normalize(cash_flows) do
-    parsed = Enum.map(cash_flows, fn {date, amount} -> {to_date(date), to_amount(amount)} end)
-    min_date = parsed |> Enum.map(&elem(&1, 0)) |> Enum.min(Date)
+    with :ok <- check_currency(Enum.map(cash_flows, fn {_date, amount} -> amount end)) do
+      parsed = Enum.map(cash_flows, fn {date, amount} -> {to_date(date), to_amount(amount)} end)
+      min_date = parsed |> Enum.map(&elem(&1, 0)) |> Enum.min(Date)
 
-    flows =
-      parsed
-      |> Enum.reduce(%{}, fn {date, amount}, acc ->
-        period = Date.diff(date, min_date) / @days_in_year
-        Map.update(acc, period, amount, &(&1 + amount))
-      end)
-      |> Map.to_list()
+      flows =
+        parsed
+        |> Enum.reduce(%{}, fn {date, amount}, acc ->
+          period = Date.diff(date, min_date) / @days_in_year
+          Map.update(acc, period, amount, &(&1 + amount))
+        end)
+        |> Map.to_list()
 
-    {:ok, flows}
+      {:ok, flows}
+    end
   rescue
     _ in [ArgumentError, FunctionClauseError] -> {:error, :invalid_date}
   end

--- a/lib/finance/shared.ex
+++ b/lib/finance/shared.ex
@@ -64,12 +64,31 @@ defmodule Finance.Shared do
   def unwrap!({:error, reason}), do: raise(ArgumentError, "could not compute: #{reason}")
 
   @doc """
-  Coerce a cash-flow amount to a float. Accepts plain numbers and, when the
-  optional Decimal dependency is present, `%Decimal{}` values.
+  Coerce a cash-flow amount to a float. Accepts plain numbers, `%Decimal{}`
+  values, and `ex_money`'s `%Money{}` (its `Decimal` amount is taken; the
+  currency is validated separately by `check_currency/1`).
   """
-  @spec to_amount(number | Decimal.t()) :: float
+  @spec to_amount(number | struct()) :: float
   def to_amount(amount) when is_number(amount), do: amount / 1
   def to_amount(amount) when is_struct(amount, Decimal), do: Decimal.to_float(amount)
+  def to_amount(amount) when is_struct(amount, Money), do: Decimal.to_float(amount.amount)
+
+  @doc """
+  Reject a series that mixes currencies. Only `%Money{}` amounts carry a currency;
+  plain numbers and `%Decimal{}` are currency-neutral and ignored. Returns `:ok`,
+  or `{:error, :mixed_currencies}` once two distinct currencies appear.
+  """
+  @spec check_currency([term]) :: :ok | {:error, :mixed_currencies}
+  def check_currency(amounts) do
+    amounts
+    |> Enum.filter(&is_struct(&1, Money))
+    |> Enum.map(& &1.currency)
+    |> Enum.uniq()
+    |> case do
+      [_first, _second | _rest] -> {:error, :mixed_currencies}
+      _none_or_one -> :ok
+    end
+  end
 
   @doc "Net present value of normalized flows at `rate`: `Σ amount / (1 + rate)^t`."
   @spec present_value([{number, number}], number) :: float

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Finance.MixProject do
   use Mix.Project
 
-  @version "1.5.0"
+  @version "1.5.1"
   @source_url "https://github.com/tubedude/finance-elixir"
 
   def project do
@@ -9,6 +9,7 @@ defmodule Finance.MixProject do
       app: :finance,
       version: @version,
       elixir: "~> 1.18",
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       description: description(),
       package: package(),
@@ -18,6 +19,11 @@ defmodule Finance.MixProject do
       docs: docs()
     ]
   end
+
+  # A stand-in `Money` struct lives in test/support so the suite can exercise the
+  # ex_money path without depending on ex_money (and its Decimal 2.x pin).
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   def cli do
     [
@@ -59,7 +65,7 @@ defmodule Finance.MixProject do
 
   defp deps do
     [
-      {:decimal, "~> 3.0", optional: true},
+      {:decimal, "~> 2.0 or ~> 3.0", optional: true},
       {:nimble_options, "~> 1.1"},
       {:ex_doc, "~> 0.34", only: :dev, runtime: false},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},

--- a/test/finance_test.exs
+++ b/test/finance_test.exs
@@ -454,6 +454,47 @@ defmodule FinanceTest do
     end
   end
 
+  describe "ex_money amounts (optional)" do
+    test "accepts %Money{} amounts, matching the numeric result" do
+      dated = [{~D[2019-01-01], money(:USD, "-1000")}, {~D[2020-01-01], money(:USD, "1100")}]
+      assert Finance.CashFlow.xirr(dated) == {:ok, 0.1}
+      assert Finance.CashFlow.irr([money(:USD, "-1000"), money(:USD, "1100")]) == {:ok, 0.1}
+      assert Finance.CashFlow.npv(0.1, [money(:USD, "-1000"), money(:USD, "1100")]) == {:ok, 0.0}
+    end
+
+    test "a plain number alongside Money is currency-neutral and allowed" do
+      assert Finance.CashFlow.irr([money(:USD, "-1000"), 1100]) == {:ok, 0.1}
+    end
+
+    test "mixing currencies is rejected across the functions" do
+      assert Finance.CashFlow.irr([money(:USD, "-1000"), money(:EUR, "1100")]) ==
+               {:error, :mixed_currencies}
+
+      dated = [{~D[2019-01-01], money(:USD, "-1000")}, {~D[2020-01-01], money(:EUR, "1100")}]
+      assert Finance.CashFlow.xirr(dated) == {:error, :mixed_currencies}
+      assert Finance.CashFlow.xnpv(0.1, dated) == {:error, :mixed_currencies}
+
+      assert Finance.CashFlow.npv(0.1, [money(:USD, "-1000"), money(:EUR, "1100")]) ==
+               {:error, :mixed_currencies}
+
+      assert Finance.CashFlow.mirr(
+               [money(:USD, "-100"), money(:EUR, "50"), money(:USD, "80")],
+               0.1,
+               0.1
+             ) ==
+               {:error, :mixed_currencies}
+    end
+
+    test "batch functions reject mixed currencies per series" do
+      series = [
+        [money(:USD, "-1000"), money(:USD, "1100")],
+        [money(:USD, "-1000"), money(:EUR, "1100")]
+      ]
+
+      assert Finance.CashFlow.irr_many(series) == [{:ok, 0.1}, {:error, :mixed_currencies}]
+    end
+  end
+
   describe "TVM scalars" do
     test "fv, pv, pmt, nper are mutually consistent" do
       # A payment that pays off pv over nper periods should give fv ~ 0.
@@ -1110,4 +1151,7 @@ defmodule FinanceTest do
       acc + amount / :math.pow(1 + rate, t)
     end)
   end
+
+  # A stand-in for ex_money's `%Money{}` (see test/support/money.ex).
+  defp money(currency, amount), do: %Money{currency: currency, amount: Decimal.new(amount)}
 end

--- a/test/support/money.ex
+++ b/test/support/money.ex
@@ -1,0 +1,7 @@
+defmodule Money do
+  @moduledoc false
+  # A minimal stand-in for ex_money's `%Money{}` — the same shape (a currency atom
+  # and a `Decimal` amount) — so the suite can exercise the ex_money code path
+  # without pulling ex_money (and its Decimal 2.x pin) into finance's own deps.
+  defstruct [:currency, :amount]
+end


### PR DESCRIPTION
Cash-flow amounts can now be [`ex_money`](https://hex.pm/packages/ex_money) `%Money{}` values, alongside numbers and `Decimal` — common when amounts come from an Ecto money column.

## What it does
- `Finance.Shared.to_amount/1` gains a `%Money{}` clause (guarded by `is_struct(_, Money)`, never a `%Money{}` pattern — the compile-time trap fixed in 1.4.4), taking the `Decimal` amount.
- A **single-currency check** rejects a series that mixes currencies with `{:error, :mixed_currencies}`. Plain numbers and `Decimal` are currency-neutral and never conflict, so `[Money.new(:USD, ...), 1100]` is fine but `[Money.new(:USD, ...), Money.new(:EUR, ...)]` errors. Wired into every cash-flow function (`xirr`/`irr`/`npv`/`xnpv`/`mirr` and the `*_many` batch forms).
- **No dependency on ex_money** — finance reads the struct structurally. That also sidesteps a real conflict: ex_money pins `decimal ~> 2.0` while finance pinned `~> 3.0`, so the two couldn't coexist. The optional `decimal` requirement is relaxed to **`~> 2.0 or ~> 3.0`**.

## Testing
A stand-in `%Money{}` in `test/support/` exercises the path (acceptance, currency-neutral mixing, per-series `:mixed_currencies`, batch) without pulling ex_money — and its Decimal 2.x pin — into finance's own deps.

**214 tests, 100% coverage, credo/dialyzer clean, 0 doc warnings.** Patch → `1.5.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)