### PR TITLE
Scan the bracket interior so even-crossing series find a root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@
   on short series, so it remains the default; select Brent with
   `solver: Finance.Solver.Brent` or `config :finance, solver: Finance.Solver.Brent`.
 
+### Fixed
+- The rate solvers now find a root when the NPV crosses zero an even number of
+  times. Bracketing compared only the two ends of the rate domain, so a series
+  with more than one IRR — where both ends share a sign — reported
+  `{:error, :did_not_converge}` even though a real rate existed (for example the
+  numpy-financial #39 series, which has IRRs near -1.8% and 12%). The bracket now
+  scans the interior of the domain, not just its extremes.
+
+### Changed
+- For a series with more than one rate, the solver returns the one nearest
+  `:guess` (default `0.1`), so a multi-IRR series resolves to the rate a
+  guess-driven spreadsheet `XIRR` would return rather than always the lowest.
+  Single-rate series are unaffected. Both `Finance.Solver.Newton` and
+  `Finance.Solver.Brent` share the bracket, so both select the same root.
+
 ## 1.5.1 — 2026-07-05
 
 ### Added

--- a/lib/finance/shared.ex
+++ b/lib/finance/shared.ex
@@ -8,7 +8,8 @@ defmodule Finance.Shared do
                     guess: [
                       type: :float,
                       default: 0.1,
-                      doc: "initial rate for the Newton-Raphson solver"
+                      doc:
+                        "initial rate for the solver; for a series with more than one rate, selects the one nearest the guess"
                     ],
                     tolerance: [
                       type: :float,
@@ -103,12 +104,59 @@ defmodule Finance.Shared do
     end)
   end
 
+  # Grid for the bracket scan: grow `1 + rate` by 5% per step, up to a rate of 1e7.
+  @scan_ratio 1.05
+  @scan_cap 1.0e7
+
   @doc false
-  # Bracket a sign change for the solvers: `{:ok, low, high}` with the NPV changing
-  # sign across `[low, high]`, or `:diverged` when none is found.
-  def bracket(flows) do
+  # Bracket a sign change for the solvers. Walk a geometric grid of rates outward
+  # from the floor; among every adjacent-sample pair whose NPV changes sign, keep
+  # the interval whose nearer edge sits closest to `guess`. Returns
+  # `{:ok, low, high}` around that root, or `:diverged` when the NPV never crosses
+  # zero.
+  #
+  # Sampling the interior — rather than comparing only the two extremes — finds a
+  # root even when the curve crosses zero an even number of times and both extremes
+  # share a sign (a series with more than one IRR). Anchoring the choice to `guess`
+  # then selects, among several roots, the one a guess-driven solver would land on,
+  # matching spreadsheet `XIRR`.
+  def bracket(flows, guess) do
     low = safe_low(flows)
-    expand(flows, low, present_value(flows, low), 1.0)
+    scan(flows, guess, low, present_value(flows, low), grid_step(low), nil)
+  end
+
+  # Next rate on the geometric grid. Growing `1 + rate` keeps the step fine near
+  # the -100% floor and coarser as the rate climbs.
+  defp grid_step(rate), do: (1.0 + rate) * @scan_ratio - 1.0
+
+  defp scan(_flows, _guess, _prev, _f_prev, rate, best) when rate > @scan_cap, do: finalize(best)
+
+  defp scan(flows, guess, prev, f_prev, rate, best) do
+    f = present_value(flows, rate)
+    crossed? = straddles_zero?(f_prev, f)
+    best = if crossed?, do: closer(best, {prev, rate}, guess), else: best
+
+    # Stop once a sign change is found entirely above the guess: it is the nearest
+    # interval above, `best` already holds the nearest at or below, and everything
+    # further out is farther still.
+    if crossed? and prev >= guess,
+      do: finalize(best),
+      else: scan(flows, guess, rate, f, grid_step(rate), best)
+  end
+
+  defp finalize(nil), do: :diverged
+  defp finalize({low, high}), do: {:ok, low, high}
+
+  # Keep whichever candidate interval sits nearer `guess`; an interval that
+  # contains the guess wins outright.
+  defp closer(nil, interval, _guess), do: interval
+
+  defp closer(best, interval, guess) do
+    if distance(interval, guess) < distance(best, guess), do: interval, else: best
+  end
+
+  defp distance({low, high}, guess) do
+    if low <= guess and guess <= high, do: 0.0, else: min(abs(low - guess), abs(high - guess))
   end
 
   # The bracket's floor. As `rate` nears -1, `(1 + rate)^t` underflows to zero for
@@ -117,15 +165,6 @@ defmodule Finance.Shared do
   defp safe_low(flows) do
     max_t = Enum.reduce(flows, 1.0, fn {t, _amount}, acc -> max(t, acc) end)
     max(:math.pow(1.0e-290, 1 / max_t), 1.0e-6) - 1.0
-  end
-
-  # Expand the upper bound until the NPV changes sign against `f_low`.
-  defp expand(_flows, _low, _f_low, high) when high > 1.0e7, do: :diverged
-
-  defp expand(flows, low, f_low, high) do
-    if straddles_zero?(f_low, present_value(flows, high)),
-      do: {:ok, low, high},
-      else: expand(flows, low, f_low, high * 2 + 1)
   end
 
   # Whether `a` and `b` sit on opposite sides of zero. Comparing signs rather than

--- a/lib/finance/solver/brent.ex
+++ b/lib/finance/solver/brent.ex
@@ -49,8 +49,9 @@ defmodule Finance.Solver.Brent do
   defp zbrent(flows, opts) do
     tol = Keyword.fetch!(opts, :tolerance)
     max_iterations = Keyword.fetch!(opts, :max_iterations)
+    guess = Keyword.fetch!(opts, :guess)
 
-    case Finance.Shared.bracket(flows) do
+    case Finance.Shared.bracket(flows, guess) do
       {:ok, a, b} ->
         fa = present_value(flows, a)
         fb = present_value(flows, b)

--- a/lib/finance/solver/newton.ex
+++ b/lib/finance/solver/newton.ex
@@ -12,6 +12,11 @@ defmodule Finance.Solver.Newton do
   Because the maintained bracket always encloses a sign change, the result is a
   genuine root rather than a stalled non-root, and a long-dated flow whose raw
   Newton step would overflow simply takes a bisection step instead.
+
+  Bracketing scans the interior of the rate domain rather than only its extremes,
+  so it finds a root even when the NPV crosses zero an even number of times (a
+  series with more than one IRR). When several roots exist it brackets the one
+  nearest `:guess`, matching what a guess-driven spreadsheet `XIRR` returns.
   """
 
   @behaviour Finance.Solver
@@ -47,7 +52,7 @@ defmodule Finance.Solver.Newton do
   # Bracket a sign change, then run the safeguarded iteration from `guess` (when it
   # falls inside the bracket) or the midpoint.
   defp rtsafe(flows, guess, tol, max_iterations) do
-    case Finance.Shared.bracket(flows) do
+    case Finance.Shared.bracket(flows, guess) do
       {:ok, a, b} ->
         bracket = orient(flows, a, b)
         x = if guess > a and guess < b, do: guess, else: (a + b) / 2

--- a/test/finance_test.exs
+++ b/test/finance_test.exs
@@ -283,12 +283,125 @@ defmodule FinanceTest do
     end
 
     test "converges over very long horizons where a high-rate probe would overflow" do
-      # Bracketing probes the NPV at rate 1.0; over 2000 periods `2^2000` overflows.
-      # Discounting with a negative exponent underflows to 0 there instead of
-      # raising, so the solve still finds the (small) root.
+      # The bracket scan samples rates out to a large cap; over 2000 periods a
+      # high-rate `(1 + rate)^-t` underflows to 0 instead of raising, so the scan
+      # completes and the solve finds the (small) root.
       {:ok, pv} = Finance.TVM.pv(0.002, 2000, -1, 0.0, 0)
       assert {:ok, rate} = Finance.TVM.rate(2000, -1, pv, 0.0, 0, precision: 10)
       assert_in_delta rate, 0.002, 1.0e-6
+    end
+
+    test "finds a root when the NPV crosses zero an even number of times" do
+      # numpy-financial #39: two big outflows then declining inflows that turn back
+      # to outflows gives two IRRs (~-1.8% and ~12%), and the NPV is negative at
+      # both ends of the domain. Comparing only the extremes misses the crossing
+      # (the pre-scan solver returned :did_not_converge); the interior scan finds
+      # it, and the default guess (0.1) selects the 12% root, as spreadsheets do.
+      series = [
+        -217_500.0,
+        -217_500.0,
+        108_466.80462450592,
+        101_129.96439328062,
+        93_793.12416205535,
+        86_456.28393083003,
+        79_119.44369960476,
+        71_782.60346837944,
+        64_445.76323715414,
+        57_108.92300592884,
+        49_772.08277470355,
+        42_435.24254347826,
+        35_098.40231225296,
+        27_761.56208102766,
+        20_424.721849802358,
+        13_087.88161857707,
+        5_751.041387351768,
+        -1_585.7988438735192,
+        -8_922.639075098821,
+        -16_259.479306324123,
+        -23_596.31953754941,
+        -30_933.159768774713,
+        -38_270.0,
+        -45_606.8402312253,
+        -52_943.680462450604,
+        -60_280.520693675906,
+        -67_617.36092490121
+      ]
+
+      assert {:ok, rate} = Finance.CashFlow.irr(series)
+      assert_in_delta rate, 0.12, 1.0e-4
+    end
+
+    test "the guess selects which root of a multi-IRR series is returned" do
+      # The textbook double-IRR series has roots at 25% and 400%. The default guess
+      # lands on the near root; a guess out by the far root selects it. This is the
+      # deliberate consequence of anchoring root selection to the guess.
+      assert Finance.CashFlow.irr([-1600, 10_000, -10_000]) == {:ok, 0.25}
+      assert Finance.CashFlow.irr([-1600, 10_000, -10_000], guess: 3.0) == {:ok, 4.0}
+    end
+
+    test "a multi-IRR series returns the root nearest the guess (numpy-financial #28)" do
+      # Roots at ~-76.9% and ~185%; the default guess (0.1) is nearer the low root,
+      # so that is returned — a genuine multi-root series has no single right answer,
+      # and this choice is guess-driven, not a defect.
+      assert Finance.CashFlow.irr([-50, -100, 600, 300, -100]) == {:ok, -0.768895}
+    end
+
+    test "a guess far outside the bracket still converges via the interior scan" do
+      # guess: -5.0 sits below the -100% floor; the scan still brackets the root and
+      # the solver reaches it from the midpoint.
+      assert Finance.CashFlow.irr([-1000, 1100], guess: -5.0) == {:ok, 0.1}
+    end
+  end
+
+  describe "real-world regression cash flows" do
+    # Series that broke other XIRR/IRR implementations but that finance-elixir
+    # resolves; pinned here so a future solver change can't silently regress them.
+
+    test "converges where node xirr's bare Newton failed (nodejs-xirr #2)" do
+      flows = [{{2018, 1, 21}, 2839.20}, {{2018, 1, 24}, 207.70}, {{2018, 4, 26}, -2526.00}]
+      assert Finance.CashFlow.xirr(flows) == {:ok, -0.514174}
+    end
+
+    test "56-year horizon (Ruby finance gem #27, case 2)" do
+      # The Ruby gem returned a nonsense ~-1e13 rate here.
+      flows = [{{1957, 1, 1}, -1000}, {{2013, 1, 1}, 390_000}]
+      assert Finance.CashFlow.xirr(flows) == {:ok, 0.112339}
+    end
+
+    test "23-year horizon (Ruby finance gem #27, case 1)" do
+      # The Ruby gem raised "failed to reduce function values" here.
+      flows = [{{1990, 1, 1}, -1000}, {{2013, 1, 1}, 390_000}]
+      assert Finance.CashFlow.xirr(flows) == {:ok, 0.295909}
+    end
+
+    test "negative-base crash class (peliot XIRR-and-XNPV #4)" do
+      # Other implementations crashed raising `(1 + rate)` to a fractional power at a
+      # negative rate; the bracket floor keeps `1 + rate > 0`, so this can't happen.
+      flows = [{{2014, 2, 27}, -4000.0}, {{2015, 3, 6}, 2050.2}]
+      assert Finance.CashFlow.xirr(flows) == {:ok, -0.480963}
+    end
+
+    test "a zero final flow is a single-signed series, not a -100% total loss" do
+      # Excel can't produce an exact -100% either; a 0 payout is neither positive nor
+      # negative, so the series has one sign. This is intentional, not java-xirr's
+      # special-cased -1.0 convention.
+      flows = [{{2020, 1, 1}, -1000}, {{2021, 1, 1}, 0}]
+      assert Finance.CashFlow.xirr(flows) == {:error, :single_signed_flow}
+    end
+
+    test "all flows on one date is insufficient data" do
+      flows = [{{2020, 1, 1}, -1000}, {{2020, 1, 1}, 1200}]
+      assert Finance.CashFlow.xirr(flows) == {:error, :insufficient_data}
+    end
+
+    test "the Actual/365 basis shows the documented leap-year quirk" do
+      # 2020-01-01 to 2021-01-01 spans a leap year: 366 days over a 365-day basis, so
+      # a 10% gross return solves to slightly under 0.1 — the Microsoft-documented
+      # XIRR leap-year behaviour, not 0.1 exactly.
+      leap = Finance.CashFlow.xirr([{{2020, 1, 1}, -1000}, {{2021, 1, 1}, 1100}])
+      assert leap == {:ok, 0.099714}
+      # The same return over a non-leap year (365 days) lands on 0.1 exactly.
+      assert Finance.CashFlow.xirr([{{2021, 1, 1}, -1000}, {{2022, 1, 1}, 1100}]) == {:ok, 0.1}
     end
   end
 
@@ -302,6 +415,18 @@ defmodule FinanceTest do
 
       assert Finance.CashFlow.irr([-1000, 500, 500, 300], solver: Finance.Solver.Brent) ==
                {:ok, 0.156579}
+    end
+
+    test "selects the same guess-anchored root as the default on a multi-IRR series" do
+      # Both solvers share the interior-scan bracket, so Brent lands on the same root.
+      assert Finance.CashFlow.irr([-1600, 10_000, -10_000], solver: Finance.Solver.Brent) ==
+               {:ok, 0.25}
+
+      assert Finance.CashFlow.irr([-1600, 10_000, -10_000],
+               guess: 3.0,
+               solver: Finance.Solver.Brent
+             ) ==
+               {:ok, 4.0}
     end
 
     test "matches the default solver across a spread of loans, including long/steep" do


### PR DESCRIPTION
## The bug

`Finance.Shared.bracket/1` compared only the two ends of the rate domain: it fixed the NPV at the floor and doubled `high`, checking those two endpoints for a sign change. When the NPV crosses zero an **even** number of times — a series with more than one IRR, where both ends share a sign — no bracket was ever found and the solve returned `{:error, :did_not_converge}`, even though a real, economically meaningful rate exists.

Reproduced against the numpy-financial [#39](https://github.com/numpy/numpy-financial/issues/39) series (IRRs near −1.8% and 12%, NPV negative at both ends of the domain): `Finance.CashFlow.irr/1` returned `:did_not_converge` on `main` where Excel/Sheets compute 12%.

## The fix

Bracketing now scans the interior of the domain on a geometric grid (5% steps in `1 + rate`) and, among every adjacent-sample sign change, returns the interval whose nearer edge is closest to `:guess`. So:

- **numpy #39** now converges to **0.12** (was `:did_not_converge`).
- Root selection is **guess-anchored**: a multi-IRR series resolves to the rate a guess-driven spreadsheet `XIRR` would return, not always the lowest. The default guess (`0.1`) reproduces `[-50,-100,600,300,-100] → -76.9%` (numpy #28) and `[-1600,10000,-10000] → 0.25`; `guess: 3.0` on the latter selects the far root `4.0`.
- Both `Finance.Solver.Newton` and `Finance.Solver.Brent` share the bracket, so they select the same root (parity-tested).
- Single-rate series are unchanged; the two `did_not_converge` cases (net-positive / no sign change) still correctly diverge.

The floor logic, overflow/underflow safety, and expansion cap are preserved — only sign-change **detection** changed, not the domain math.

## Tests

New regression coverage: the numpy #39 even-crossing case, guess-anchored root selection (both solvers), and real-world cash flows that broke other implementations (nodejs-xirr #2, the Ruby finance gem's 56y/23y horizons, peliot's negative-base crash class), plus the zero-payout / same-date / leap-year day-count conventions.

233 tests across seeds, `credo --strict` and dialyzer clean, 100% coverage, 0 doc warnings. Ships under **1.6.0** alongside `Finance.Solver.Brent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)