### PR TITLE
Correct the solver description in the CashFlow moduledoc

### DIFF
--- a/lib/finance/cash_flow.ex
+++ b/lib/finance/cash_flow.ex
@@ -9,8 +9,9 @@ defmodule Finance.CashFlow do
   amounts at equally spaced periods `0, 1, 2, …`.
 
   `xirr`/`irr` find the rate `r` that brings the net present value to zero,
-  `Σ cf_i / (1 + r)^t_i = 0`, using `Finance.Solver` (Newton-Raphson with a
-  bisection fallback by default).
+  `Σ cf_i / (1 + r)^t_i = 0`, using `Finance.Solver` (a safeguarded
+  Newton-Raphson by default, with a derivative-free `Finance.Solver.Brent`
+  available).
 
   ## Options
 


### PR DESCRIPTION
`Finance.CashFlow`'s moduledoc described the default solver as "Newton-Raphson with a bisection fallback." That was the old 1.0 solver; since 1.4.3 the default is a safeguarded Newton-Raphson (`rtsafe`), which interleaves a bisection step per iteration rather than falling back to bisection after Newton gives up. Reworded, and named the derivative-free `Finance.Solver.Brent` alternative.

Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)