### PR TITLE
Guard against rates at or below -100% and fix rounding in ytm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,19 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - elixir: "1.18"
-            otp: "27"
-          - elixir: "1.20"
-            otp: "29"
+          - elixir: "1.15.8"
+            otp: "25.3.2.21"
+          - elixir: "1.18.4"
+            otp: "27.3.4.13"
+          - elixir: "1.20.1"
+            otp: "29.0.2"
+            lint: true
           # Exercise the lower bound of `decimal ~> 2.0 or ~> 3.0`.
-          - elixir: "1.20"
-            otp: "29"
+          - elixir: "1.20.1"
+            otp: "29.0.2"
             decimal: "2"
     steps:
       - uses: actions/checkout@v4
@@ -35,8 +39,12 @@ jobs:
         if: matrix.decimal == '2'
         run: sed -i 's/~> 2.0 or ~> 3.0/~> 2.0/' mix.exs && mix deps.unlock decimal
       - run: mix deps.get
+      # Format and lint only on the newest version — the formatter's output and
+      # Credo can differ across Elixir releases; older versions just run the suite.
       - run: mix format --check-formatted
+        if: matrix.lint
       - run: mix credo --strict
+        if: matrix.lint
       - run: mix test
 
   coverage:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 - Discounting is centralized in one overflow-safe `(1 + rate)^-t` helper, so the
   bond and returns metrics no longer use a divide form that could overflow. The
   bracket scan also stops one step sooner when the root sits at the guess.
+- The minimum Elixir is lowered to `~> 1.15` (was `~> 1.18`); CI covers 1.15
+  through 1.20.
 
 ## 1.6.0 — 2026-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 1.6.1 — 2026-07-06
+
+### Fixed
+- A rate at or below -100% now returns `{:error, :undefined}` instead of raising
+  `ArithmeticError` (or returning silent garbage) everywhere `(1 + rate)^t` is
+  computed: `CashFlow.xnpv`/`npv`/`mirr`, `TVM.fv`/`pv`/`pmt`/`amortization_schedule`,
+  `Bonds.price` and the risk metrics, `Returns.discounted_payback_period`/
+  `profitability_index`/`twr`, `Rates.effective_annual_rate`, and
+  `Depreciation.sln` (which also rejects a non-positive `life`).
+  `Rates.nominal_rate(-1.0, m)` now returns `-m`, so it stays the exact inverse of
+  `effective_annual_rate` at total loss.
+- `Bonds.duration`/`modified_duration`/`convexity` return `{:error, :undefined}`
+  when a negative coupon drives the bond price to zero, rather than a nonsensical
+  value or a crash.
+- `Bonds.ytm` and `Returns.profitability_index` no longer round an intermediate
+  value before the final round (`ytm`'s periodic rounding was amplified by `freq`).
+  Both compute at full precision and round once.
+- `xirr(dates, [])` returns `{:error, :mismatched_lengths}` instead of crashing — an
+  empty amounts list is the two-list form, not options.
+- A malformed cash-flow amount is no longer mislabeled `{:error, :invalid_date}`.
+  Date parsing uses `Date.from_erl/1` (removing a broad `rescue`); a bad amount is a
+  caller error and raises, like other malformed inputs.
+
+### Changed
+- `:precision` is validated as `0..15` (the range `Float.round/2` accepts) rather
+  than any non-negative integer, and `:guess`/`:tolerance` now accept integers as
+  well as floats.
+- `Bonds` requires an integer coupon frequency (`freq`), matching its documented
+  `pos_integer`; `Depreciation.syd` rejects a fractional `period`, matching `ddb`/`db`.
+- Discounting is centralized in one overflow-safe `(1 + rate)^-t` helper, so the
+  bond and returns metrics no longer use a divide form that could overflow. The
+  bracket scan also stops one step sooner when the root sits at the guess.
+
 ## 1.6.0 — 2026-07-05
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,9 +15,11 @@ supported — both without a hard dependency, guarded with `is_struct(value, Mod
 
 ## Toolchain
 
-Elixir/OTP are pinned in `.tool-versions` (asdf): **Elixir 1.20 / OTP 29**.
-`mix.exs` requires `~> 1.18`. CI (`.github/workflows/ci.yml`) tests on 1.18/27 and
-1.20/29, plus a job that runs the suite against Decimal 2.x.
+`.tool-versions` (asdf) pins local dev to **Elixir 1.20 / OTP 29**, but `mix.exs`
+requires only `~> 1.15`. CI (`.github/workflows/ci.yml`) tests 1.15/25, 1.18/27,
+and 1.20/29, plus a job that runs the suite against Decimal 2.x. `mix format` and
+`mix credo` run only on the newest version (the `lint` matrix flag), since the
+formatter's output can differ across Elixir releases.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ a rayon thread pool — add it and point `:solver` at it:
 ```elixir
 # mix.exs
 {:finance, "~> 1.6"},
-{:finance_rustler, "~> 0.1"}
+{:finance_rustler, "~> 0.2"}
 
 # config/config.exs
 config :finance, solver: FinanceRustler.Solver

--- a/lib/finance.ex
+++ b/lib/finance.ex
@@ -23,18 +23,20 @@ defmodule Finance do
 
   ## Deprecated flat API
 
-  Every function is also available directly on `Finance` (e.g. `Finance.xirr/1`),
-  but those delegators are **deprecated** and will be removed in 2.0 — call the
-  domain module instead, for example:
+  The functions that lived directly on `Finance` before 1.2 (e.g. `Finance.xirr/1`)
+  still work, but those delegators are **deprecated** and will be removed in 2.0 —
+  call the domain module instead, for example:
 
       Finance.CashFlow.xirr([{~D[2019-01-01], -1000}, {~D[2020-01-01], 1100}])
       #=> {:ok, 0.1}
 
+  Functions added since 1.2 exist only on their domain module.
+
   ## Options
 
-  The rate-finding and value functions take an optional keyword list. Options are
-  validated with `nimble_options`: an unknown key or bad value raises, while
-  problems with the data come back as `{:error, reason}`.
+  The rate functions and the `npv`/`xnpv` value functions take an optional keyword
+  list. Options are validated with `nimble_options`: an unknown key or bad value
+  raises, while problems with the data come back as `{:error, reason}`.
 
   #{Finance.Shared.options_docs()}
   """

--- a/lib/finance/bonds.ex
+++ b/lib/finance/bonds.ex
@@ -18,7 +18,14 @@ defmodule Finance.Bonds do
   """
 
   import Finance.Shared,
-    only: [present_value: 2, round_value: 2, options: 1, resolve_solver: 1, unwrap!: 1]
+    only: [
+      present_value: 2,
+      discount_factor: 2,
+      round_value: 2,
+      options: 1,
+      resolve_solver: 1,
+      unwrap!: 1
+    ]
 
   @type error :: Finance.error()
   @type option :: Finance.option()
@@ -39,15 +46,11 @@ defmodule Finance.Bonds do
           {:ok, float} | {:error, error}
   def price(face, coupon_rate, ytm, years, freq \\ 2, opts \\ [])
       when is_number(face) and is_number(coupon_rate) and is_number(ytm) and is_number(years) and
-             is_number(freq) and is_list(opts) do
-    case periods_valid(years, freq) do
-      nil ->
-        {:error, :undefined}
-
-      n ->
-        opts = options(opts)
-        value = present_value(bond_flows(face, coupon_rate, n, freq), ytm / freq)
-        {:ok, round_value(value, opts)}
+             is_integer(freq) and is_list(opts) do
+    with {:ok, n} <- coupon_periods(years, freq),
+         :ok <- check_yield(ytm, freq) do
+      value = present_value(bond_flows(face, coupon_rate, n, freq), ytm / freq)
+      {:ok, round_value(value, options(opts))}
     end
   end
 
@@ -72,19 +75,19 @@ defmodule Finance.Bonds do
           {:ok, float} | {:error, error}
   def ytm(face, coupon_rate, price, years, freq \\ 2, opts \\ [])
       when is_number(face) and is_number(coupon_rate) and is_number(price) and is_number(years) and
-             is_number(freq) and is_list(opts) do
-    case periods_valid(years, freq) do
-      nil ->
-        {:error, :undefined}
+             is_integer(freq) and is_list(opts) do
+    with {:ok, n} <- coupon_periods(years, freq) do
+      opts = options(opts)
+      flows = [{0.0, -price * 1.0} | bond_flows(face, coupon_rate, n, freq)]
 
-      n ->
-        opts = options(opts)
-        flows = [{0.0, -price * 1.0} | bond_flows(face, coupon_rate, n, freq)]
+      # Solve the per-period rate at high precision, then round the annualized
+      # yield once. Rounding `periodic` first would let `freq` amplify that
+      # rounding error into the last reported digit.
+      solver_opts = Keyword.update!(opts, :precision, &max(&1, 12))
 
-        with {:ok, periodic} <- resolve_solver(opts).solve(flows, opts) do
-          # Annualize the per-period rate to the requested precision.
-          {:ok, round_value(periodic * freq, opts)}
-        end
+      with {:ok, periodic} <- resolve_solver(opts).solve(flows, solver_opts) do
+        {:ok, round_value(periodic * freq, opts)}
+      end
     end
   end
 
@@ -109,9 +112,9 @@ defmodule Finance.Bonds do
   @spec duration(number, number, number, pos_integer, [option]) ::
           {:ok, float} | {:error, error}
   def duration(coupon_rate, ytm, years, freq \\ 2, opts \\ [])
-      when is_number(coupon_rate) and is_number(ytm) and is_number(years) and is_number(freq) and
+      when is_number(coupon_rate) and is_number(ytm) and is_number(years) and is_integer(freq) and
              is_list(opts) do
-    with_metric(coupon_rate, years, freq, opts, fn flows ->
+    with_metric(coupon_rate, ytm, years, freq, opts, fn flows ->
       macaulay(flows, ytm / freq, freq)
     end)
   end
@@ -135,10 +138,10 @@ defmodule Finance.Bonds do
   @spec modified_duration(number, number, number, pos_integer, [option]) ::
           {:ok, float} | {:error, error}
   def modified_duration(coupon_rate, ytm, years, freq \\ 2, opts \\ [])
-      when is_number(coupon_rate) and is_number(ytm) and is_number(years) and is_number(freq) and
+      when is_number(coupon_rate) and is_number(ytm) and is_number(years) and is_integer(freq) and
              is_list(opts) do
-    with_metric(coupon_rate, years, freq, opts, fn flows ->
-      macaulay(flows, ytm / freq, freq) / (1 + ytm / freq)
+    with_metric(coupon_rate, ytm, years, freq, opts, fn flows ->
+      with {:ok, m} <- macaulay(flows, ytm / freq, freq), do: {:ok, m / (1 + ytm / freq)}
     end)
   end
 
@@ -161,9 +164,9 @@ defmodule Finance.Bonds do
   @spec convexity(number, number, number, pos_integer, [option]) ::
           {:ok, float} | {:error, error}
   def convexity(coupon_rate, ytm, years, freq \\ 2, opts \\ [])
-      when is_number(coupon_rate) and is_number(ytm) and is_number(years) and is_number(freq) and
+      when is_number(coupon_rate) and is_number(ytm) and is_number(years) and is_integer(freq) and
              is_list(opts) do
-    with_metric(coupon_rate, years, freq, opts, fn flows ->
+    with_metric(coupon_rate, ytm, years, freq, opts, fn flows ->
       convexity_value(flows, ytm / freq, freq)
     end)
   end
@@ -176,49 +179,63 @@ defmodule Finance.Bonds do
 
   # --- helpers -------------------------------------------------------------
 
-  # Shared shape for the risk metrics: validate periods, build unit-face flows,
-  # apply `fun`, and round. Keeps each public metric a one-liner.
-  defp with_metric(coupon_rate, years, freq, opts, fun) do
-    case periods_valid(years, freq) do
-      nil -> {:error, :undefined}
-      n -> {:ok, round_value(fun.(bond_flows(1, coupon_rate, n, freq)), options(opts))}
+  # Shared shape for the risk metrics; keeps each public metric a one-liner. `fun`
+  # returns `{:ok, value} | {:error, :undefined}` (undefined when the yield drives
+  # the unit-face price to zero, e.g. a negative coupon).
+  defp with_metric(coupon_rate, ytm, years, freq, opts, fun) do
+    with {:ok, n} <- coupon_periods(years, freq),
+         :ok <- check_yield(ytm, freq),
+         {:ok, value} <- fun.(bond_flows(1, coupon_rate, n, freq)) do
+      {:ok, round_value(value, options(opts))}
     end
   end
 
-  # Whole, positive coupon-period count, or nil when the inputs are degenerate.
-  defp periods_valid(years, freq) do
+  # Whole, positive coupon-period count.
+  defp coupon_periods(years, freq) do
     n = years * freq
     t = trunc(n)
-    if freq > 0 and n == t and t > 0, do: t, else: nil
+    if freq > 0 and n == t and t > 0, do: {:ok, t}, else: {:error, :undefined}
   end
 
+  # The per-period yield must keep `1 + ytm/freq` positive for discounting.
+  defp check_yield(ytm, freq) when 1 + ytm / freq <= 0, do: {:error, :undefined}
+  defp check_yield(_ytm, _freq), do: :ok
+
   # Coupon + redemption cash flows on `face`, as [{period, amount}], k = 1..n.
-  # The face value is added onto the final coupon at period n.
   defp bond_flows(face, coupon_rate, n, freq) do
     coupon = face * coupon_rate / freq
 
     Enum.map(1..n, fn k ->
       amount = if k == n, do: coupon + face, else: coupon
-      {k * 1.0, amount * 1.0}
+      {k * 1.0, amount}
     end)
   end
 
   defp weighted_pv(flows, r) do
-    Enum.map(flows, fn {k, cf} -> {k, cf / :math.pow(1 + r, k)} end)
+    Enum.map(flows, fn {k, cf} -> {k, cf * discount_factor(r, k)} end)
   end
 
   # Macaulay duration in years: PV-weighted average period, divided by freq.
+  # Undefined when the price side is non-positive (only a negative coupon can do it).
   defp macaulay(flows, r, freq) do
     weighted = weighted_pv(flows, r)
-    price = Enum.reduce(weighted, 0.0, fn {_k, pv}, acc -> acc + pv end)
-    Enum.reduce(weighted, 0.0, fn {k, pv}, acc -> acc + k * pv end) / price / freq
+    price = Enum.sum_by(weighted, fn {_k, pv} -> pv end)
+
+    if price <= 0.0,
+      do: {:error, :undefined},
+      else: {:ok, Enum.sum_by(weighted, fn {k, pv} -> k * pv end) / price / freq}
   end
 
   # Convexity in years²: the k·(k+1)-weighted PV sum, annualized by freq².
   defp convexity_value(flows, r, freq) do
     weighted = weighted_pv(flows, r)
-    price = Enum.reduce(weighted, 0.0, fn {_k, pv}, acc -> acc + pv end)
-    num = Enum.reduce(weighted, 0.0, fn {k, pv}, acc -> acc + k * (k + 1) * pv end)
-    num / price / :math.pow(1 + r, 2) / :math.pow(freq, 2)
+    price = Enum.sum_by(weighted, fn {_k, pv} -> pv end)
+
+    if price <= 0.0 do
+      {:error, :undefined}
+    else
+      num = Enum.sum_by(weighted, fn {k, pv} -> k * (k + 1) * pv end)
+      {:ok, num / price / :math.pow(1 + r, 2) / :math.pow(freq, 2)}
+    end
   end
 end

--- a/lib/finance/bonds.ex
+++ b/lib/finance/bonds.ex
@@ -219,22 +219,22 @@ defmodule Finance.Bonds do
   # Undefined when the price side is non-positive (only a negative coupon can do it).
   defp macaulay(flows, r, freq) do
     weighted = weighted_pv(flows, r)
-    price = Enum.sum_by(weighted, fn {_k, pv} -> pv end)
+    price = Enum.reduce(weighted, 0.0, fn {_k, pv}, acc -> acc + pv end)
 
     if price <= 0.0,
       do: {:error, :undefined},
-      else: {:ok, Enum.sum_by(weighted, fn {k, pv} -> k * pv end) / price / freq}
+      else: {:ok, Enum.reduce(weighted, 0.0, fn {k, pv}, acc -> acc + k * pv end) / price / freq}
   end
 
   # Convexity in years²: the k·(k+1)-weighted PV sum, annualized by freq².
   defp convexity_value(flows, r, freq) do
     weighted = weighted_pv(flows, r)
-    price = Enum.sum_by(weighted, fn {_k, pv} -> pv end)
+    price = Enum.reduce(weighted, 0.0, fn {_k, pv}, acc -> acc + pv end)
 
     if price <= 0.0 do
       {:error, :undefined}
     else
-      num = Enum.sum_by(weighted, fn {k, pv} -> k * (k + 1) * pv end)
+      num = Enum.reduce(weighted, 0.0, fn {k, pv}, acc -> acc + k * (k + 1) * pv end)
       {:ok, num / price / :math.pow(1 + r, 2) / :math.pow(freq, 2)}
     end
   end

--- a/lib/finance/cash_flow.ex
+++ b/lib/finance/cash_flow.ex
@@ -30,6 +30,7 @@ defmodule Finance.CashFlow do
       options: 1,
       resolve_solver: 1,
       present_value: 2,
+      discount_factor: 2,
       check_currency: 1
     ]
 
@@ -76,7 +77,7 @@ defmodule Finance.CashFlow do
   @spec xirr([cash_flow], [option]) :: {:ok, rate} | {:error, error}
   @spec xirr([date], [amount]) :: {:ok, rate} | {:error, error}
   def xirr(first, second) when is_list(first) and is_list(second) do
-    if options?(second) do
+    if pairs?(first) and options?(second) do
       compute(first, second)
     else
       zip(first, second, [])
@@ -165,7 +166,8 @@ defmodule Finance.CashFlow do
       when is_number(rate) and is_list(cash_flows) and is_list(opts) do
     opts = options(opts)
 
-    with {:ok, flows} <- normalize(cash_flows) do
+    with :ok <- check_rate(rate),
+         {:ok, flows} <- normalize(cash_flows) do
       {:ok, round_value(present_value(flows, rate), opts)}
     end
   end
@@ -263,7 +265,8 @@ defmodule Finance.CashFlow do
       when is_number(rate) and is_list(amounts) and is_list(opts) do
     opts = options(opts)
 
-    with :ok <- check_currency(amounts) do
+    with :ok <- check_rate(rate),
+         :ok <- check_currency(amounts) do
       {:ok, round_value(present_value(periodic_flows(amounts), rate), opts)}
     end
   end
@@ -301,7 +304,8 @@ defmodule Finance.CashFlow do
       cond do
         n < 2 -> {:error, :insufficient_data}
         not signed_both_ways?(values) -> {:error, :single_signed_flow}
-        true -> {:ok, round_value(modified_irr(values, finance_rate, reinvest_rate, n), opts)}
+        1 + finance_rate <= 0 or 1 + reinvest_rate <= 0 -> {:error, :undefined}
+        true -> {:ok, round_value(modified_irr(values, finance_rate, reinvest_rate), opts)}
       end
     end
   end
@@ -312,34 +316,38 @@ defmodule Finance.CashFlow do
     amounts |> mirr(finance_rate, reinvest_rate, opts) |> unwrap!()
   end
 
-  defp modified_irr(values, finance_rate, reinvest_rate, n) do
-    periods = n - 1
+  defp modified_irr(values, finance_rate, reinvest_rate) do
+    periods = length(values) - 1
+    indexed = Enum.with_index(values)
 
     future_of_inflows =
-      values
-      |> Enum.with_index()
-      |> Enum.reduce(0.0, fn {value, i}, acc ->
-        if value > 0, do: acc + value * :math.pow(1 + reinvest_rate, periods - i), else: acc
-      end)
+      indexed
+      |> Enum.filter(fn {value, _i} -> value > 0 end)
+      |> Enum.sum_by(fn {value, i} -> value * :math.pow(1 + reinvest_rate, periods - i) end)
 
     present_of_outflows =
-      values
-      |> Enum.with_index()
-      |> Enum.reduce(0.0, fn {value, i}, acc ->
-        if value < 0, do: acc + value / :math.pow(1 + finance_rate, i), else: acc
-      end)
+      indexed
+      |> Enum.filter(fn {value, _i} -> value < 0 end)
+      |> Enum.sum_by(fn {value, i} -> value * discount_factor(finance_rate, i) end)
 
     :math.pow(future_of_inflows / -present_of_outflows, 1 / periods) - 1
   end
 
   # === Dispatch & normalization ============================================
 
-  # An empty list or a proper keyword list is treated as options. A list of
-  # `{date, amount}` pairs is not a keyword list (its keys are dates, not
-  # atoms), and a list of numeric amounts is not either — so the two input
-  # shapes are never confused.
+  # `xirr(first, second)` is `xirr(pairs, opts)` only when `first` is a list of
+  # `{date, amount}` pairs and `second` is options; otherwise it's the two-list
+  # `xirr(dates, amounts)` form. A `{date, amount}` pair is a 2-tuple, while a bare
+  # date is a `%Date{}` or a `{y, m, d}` 3-tuple, so the head disambiguates.
+  defp pairs?([]), do: true
+  defp pairs?(list), do: match?([{_, _} | _], list)
+
   defp options?([]), do: true
   defp options?(list), do: Keyword.keyword?(list)
+
+  # A discount rate at or below -100% has no meaningful `(1 + rate)^t`.
+  defp check_rate(rate) when 1 + rate <= 0, do: {:error, :undefined}
+  defp check_rate(_rate), do: :ok
 
   defp zip(dates, values, opts) when length(dates) == length(values) do
     dates |> Enum.zip(values) |> compute(opts)
@@ -397,8 +405,10 @@ defmodule Finance.CashFlow do
   defp normalize([]), do: {:error, :insufficient_data}
 
   defp normalize(cash_flows) do
-    with :ok <- check_currency(Enum.map(cash_flows, fn {_date, amount} -> amount end)) do
-      parsed = Enum.map(cash_flows, fn {date, amount} -> {to_date(date), to_amount(amount)} end)
+    amounts = Enum.map(cash_flows, fn {_date, amount} -> amount end)
+
+    with :ok <- check_currency(amounts),
+         {:ok, parsed} <- parse_dates(cash_flows) do
       min_date = parsed |> Enum.map(&elem(&1, 0)) |> Enum.min(Date)
 
       flows =
@@ -407,33 +417,39 @@ defmodule Finance.CashFlow do
           period = Date.diff(date, min_date) / @days_in_year
           Map.update(acc, period, amount, &(&1 + amount))
         end)
-        |> Map.to_list()
+        |> Enum.sort()
 
       {:ok, flows}
     end
-  rescue
-    _ in [ArgumentError, FunctionClauseError] -> {:error, :invalid_date}
   end
 
-  # Build position-indexed flows (period 0, 1, 2, …) for the periodic functions.
+  # A malformed amount is a caller bug, left to raise rather than be reported as an
+  # :invalid_date.
+  defp parse_dates(cash_flows) do
+    Enum.reduce_while(cash_flows, {:ok, []}, fn {date, amount}, {:ok, acc} ->
+      case to_date(date) do
+        {:ok, parsed_date} -> {:cont, {:ok, [{parsed_date, to_amount(amount)} | acc]}}
+        {:error, _reason} -> {:halt, {:error, :invalid_date}}
+      end
+    end)
+  end
+
   defp periodic_flows(amounts) do
     amounts
     |> Enum.with_index()
     |> Enum.map(fn {amount, index} -> {index / 1, to_amount(amount)} end)
   end
 
-  defp to_date(%Date{} = date), do: date
-  defp to_date({y, m, d}), do: Date.from_erl!({y, m, d})
+  defp to_date(%Date{} = date), do: {:ok, date}
+  defp to_date({y, m, d}), do: Date.from_erl({y, m, d})
 
-  defp validate(flows) do
-    amounts = Enum.map(flows, &elem(&1, 1))
-
-    cond do
-      length(flows) < 2 -> {:error, :insufficient_data}
-      not signed_both_ways?(amounts) -> {:error, :single_signed_flow}
-      true -> :ok
-    end
+  defp validate([_, _ | _] = flows) do
+    if signed_both_ways?(Enum.map(flows, &elem(&1, 1))),
+      do: :ok,
+      else: {:error, :single_signed_flow}
   end
+
+  defp validate(_flows), do: {:error, :insufficient_data}
 
   defp signed_both_ways?(amounts) do
     Enum.any?(amounts, &(&1 > 0)) and Enum.any?(amounts, &(&1 < 0))

--- a/lib/finance/cash_flow.ex
+++ b/lib/finance/cash_flow.ex
@@ -323,12 +323,14 @@ defmodule Finance.CashFlow do
     future_of_inflows =
       indexed
       |> Enum.filter(fn {value, _i} -> value > 0 end)
-      |> Enum.sum_by(fn {value, i} -> value * :math.pow(1 + reinvest_rate, periods - i) end)
+      |> Enum.reduce(0.0, fn {value, i}, acc ->
+        acc + value * :math.pow(1 + reinvest_rate, periods - i)
+      end)
 
     present_of_outflows =
       indexed
       |> Enum.filter(fn {value, _i} -> value < 0 end)
-      |> Enum.sum_by(fn {value, i} -> value * discount_factor(finance_rate, i) end)
+      |> Enum.reduce(0.0, fn {value, i}, acc -> acc + value * discount_factor(finance_rate, i) end)
 
     :math.pow(future_of_inflows / -present_of_outflows, 1 / periods) - 1
   end

--- a/lib/finance/depreciation.ex
+++ b/lib/finance/depreciation.ex
@@ -25,10 +25,10 @@ defmodule Finance.Depreciation do
   @spec sln(number, number, number) :: {:ok, float} | {:error, error}
   def sln(cost, salvage, life)
       when is_number(cost) and is_number(salvage) and is_number(life) do
-    if life == 0 do
+    if life <= 0 do
       {:error, :undefined}
     else
-      {:ok, (cost - salvage) / life * 1.0}
+      {:ok, (cost - salvage) / life}
     end
   end
 
@@ -54,10 +54,12 @@ defmodule Finance.Depreciation do
   @spec syd(number, number, number, number) :: {:ok, float} | {:error, error}
   def syd(cost, salvage, life, period)
       when is_number(cost) and is_number(salvage) and is_number(life) and is_number(period) do
-    if life <= 0 or period < 1 or period > life do
+    n = trunc(period)
+
+    if life <= 0 or period != n or n < 1 or n > life do
       {:error, :undefined}
     else
-      {:ok, (cost - salvage) * (life - period + 1) * 2 / (life * (life + 1)) * 1.0}
+      {:ok, (cost - salvage) * (life - period + 1) * 2 / (life * (life + 1))}
     end
   end
 

--- a/lib/finance/rates.ex
+++ b/lib/finance/rates.ex
@@ -22,10 +22,11 @@ defmodule Finance.Rates do
   """
   @spec effective_annual_rate(number, number) :: {:ok, float} | {:error, error}
   def effective_annual_rate(nominal, m) when is_number(nominal) and is_number(m) do
-    if m <= 0 do
-      {:error, :undefined}
-    else
-      {:ok, :math.pow(1 + nominal / m, m) - 1}
+    cond do
+      m <= 0 -> {:error, :undefined}
+      # A negative base raised to a fractional `m` has no real value.
+      1 + nominal / m < 0 -> {:error, :undefined}
+      true -> {:ok, :math.pow(1 + nominal / m, m) - 1}
     end
   end
 
@@ -48,7 +49,9 @@ defmodule Finance.Rates do
   def nominal_rate(effective, m) when is_number(effective) and is_number(m) do
     cond do
       m <= 0 -> {:error, :undefined}
-      1 + effective <= 0 -> {:error, :undefined}
+      # `1 + effective == 0` is the total-loss case: `pow(0, 1/m)` is 0, so the
+      # inverse of `effective_annual_rate` still holds there.
+      1 + effective < 0 -> {:error, :undefined}
       true -> {:ok, m * (:math.pow(1 + effective, 1 / m) - 1)}
     end
   end

--- a/lib/finance/returns.ex
+++ b/lib/finance/returns.ex
@@ -13,7 +13,7 @@ defmodule Finance.Returns do
   periods 1, 2, ….
   """
 
-  import Finance.Shared, only: [round_value: 2, unwrap!: 1]
+  import Finance.Shared, only: [round_value: 2, unwrap!: 1, present_value: 2, discount_factor: 2]
 
   @type error :: Finance.error()
 
@@ -76,16 +76,15 @@ defmodule Finance.Returns do
   @spec volatility([number], keyword) :: {:ok, float} | {:error, error}
   def volatility(prices, opts \\ []) when is_list(prices) do
     opts = NimbleOptions.validate!(opts, @volatility_options_schema)
-    returns = period_returns(prices, Keyword.fetch!(opts, :returns))
 
-    cond do
-      returns == :error ->
+    case period_returns(prices, Keyword.fetch!(opts, :returns)) do
+      :error ->
         {:error, :undefined}
 
-      length(returns) < 2 ->
+      returns when length(returns) < 2 ->
         {:error, :insufficient_data}
 
-      true ->
+      returns ->
         {:ok, round_value(annualise(returns, Keyword.fetch!(opts, :periods_per_year)), opts)}
     end
   end
@@ -149,7 +148,7 @@ defmodule Finance.Returns do
   @doc """
   Discounted payback period — like `payback_period/2`, but recovers the outlay
   from cash flows discounted at `rate` (so it accounts for the time value of
-  money and is always at least as long as the plain payback).
+  money and, for a non-negative rate, is at least as long as the plain payback).
 
       iex> Finance.Returns.discounted_payback_period([-1000, 600, 600, 600], 0.1)
       {:ok, 1.916667}
@@ -158,7 +157,10 @@ defmodule Finance.Returns do
   def discounted_payback_period(cash_flows, rate, opts \\ [])
       when is_list(cash_flows) and is_number(rate) and is_list(opts) do
     opts = NimbleOptions.validate!(opts, @precision_options_schema)
-    recovery_result(discount_flows(cash_flows, rate), opts)
+
+    if 1 + rate <= 0,
+      do: {:error, :undefined},
+      else: recovery_result(discount_flows(cash_flows, rate), opts)
   end
 
   @doc "Same as `discounted_payback_period/3`, but returns the value directly and raises `ArgumentError` on error."
@@ -206,15 +208,19 @@ defmodule Finance.Returns do
       {:ok, 0.082432}
   """
   @spec twr([number], keyword) :: {:ok, float} | {:error, error}
-  def twr(period_returns, opts \\ []) when is_list(period_returns) and is_list(opts) do
+  def twr(returns, opts \\ []) when is_list(returns) and is_list(opts) do
     opts = NimbleOptions.validate!(opts, @twr_options_schema)
 
     cond do
-      period_returns == [] -> {:error, :insufficient_data}
-      not Enum.all?(period_returns, &is_number/1) -> {:error, :undefined}
-      true -> {:ok, round_value(time_weighted(period_returns, opts), opts)}
+      returns == [] -> {:error, :insufficient_data}
+      not Enum.all?(returns, &valid_return?/1) -> {:error, :undefined}
+      true -> {:ok, round_value(time_weighted(returns, opts), opts)}
     end
   end
+
+  # A period return below -100% has no meaning and would push `1 + cumulative`
+  # negative, so annualisation's `:math.pow` would leave its real domain.
+  defp valid_return?(r), do: is_number(r) and r >= -1
 
   @doc "Same as `twr/2`, but returns the value directly and raises `ArgumentError` on error."
   @spec twr!([number], keyword) :: float
@@ -286,20 +292,22 @@ defmodule Finance.Returns do
   defp discount_flows(flows, rate) do
     flows
     |> Enum.with_index()
-    |> Enum.map(fn {flow, i} -> flow / :math.pow(1 + rate, i) end)
+    |> Enum.map(fn {flow, i} -> flow * discount_factor(rate, i) end)
   end
 
   # --- profitability index ------------------------------------------------
 
+  defp profitability(_cash_flows, rate, _opts) when 1 + rate <= 0, do: {:error, :undefined}
   defp profitability([], _rate, _opts), do: {:error, :insufficient_data}
-  defp profitability([initial | _], _rate, _opts) when initial >= 0, do: {:error, :undefined}
 
-  defp profitability(cash_flows, rate, opts) do
-    precision = Keyword.fetch!(opts, :precision)
+  defp profitability([initial | _], _rate, _opts) when is_number(initial) and initial >= 0,
+    do: {:error, :undefined}
 
-    with {:ok, npv} <- Finance.CashFlow.npv(rate, cash_flows, precision: precision) do
-      {:ok, round_value(1 + npv / -hd(cash_flows), opts)}
-    end
+  defp profitability([initial | _] = cash_flows, rate, opts) do
+    # PI = 1 + NPV / -initial_outlay. Discount at full precision and round once,
+    # so the ratio isn't skewed by a pre-rounded NPV.
+    flows = cash_flows |> Enum.with_index() |> Enum.map(fn {cf, i} -> {i * 1.0, cf * 1.0} end)
+    {:ok, round_value(1 + present_value(flows, rate) / -initial, opts)}
   end
 
   # --- time-weighted return -----------------------------------------------

--- a/lib/finance/shared.ex
+++ b/lib/finance/shared.ex
@@ -6,13 +6,13 @@ defmodule Finance.Shared do
 
   @options_schema NimbleOptions.new!(
                     guess: [
-                      type: :float,
+                      type: {:or, [:float, :integer]},
                       default: 0.1,
                       doc:
                         "initial rate for the solver; for a series with more than one rate, selects the one nearest the guess"
                     ],
                     tolerance: [
-                      type: :float,
+                      type: {:or, [:float, :integer]},
                       default: 1.0e-9,
                       doc:
                         "convergence threshold on the rate: iterating stops once the step (or bracket width) falls below it"
@@ -24,9 +24,9 @@ defmodule Finance.Shared do
                         "cap on solver iterations; the current bracketed estimate is returned if it is reached"
                     ],
                     precision: [
-                      type: :non_neg_integer,
+                      type: {:in, 0..15},
                       default: 6,
-                      doc: "decimal places the result is rounded to"
+                      doc: "decimal places the result is rounded to (0..15)"
                     ],
                     solver: [
                       type: :atom,
@@ -56,9 +56,19 @@ defmodule Finance.Shared do
   end
 
   @doc "Round a result to the `:precision` in `opts`; `+ 0.0` collapses a negative zero to `0.0`."
-  @spec round_value(number, keyword) :: float
+  @spec round_value(float, keyword) :: float
   def round_value(value, opts) do
     Float.round(value, Keyword.fetch!(opts, :precision)) + 0.0
+  end
+
+  @doc false
+  # Run `fun`, mapping an arithmetic overflow to `:diverged` rather than crashing.
+  # `:math.pow` at an extreme rate on a long-dated flow signals overflow only by
+  # raising, so a rescue is the only way to turn it into a solver error.
+  def safely(fun) do
+    fun.()
+  rescue
+    ArithmeticError -> :diverged
   end
 
   @doc "Unwrap an `{:ok, value}`; raise `ArgumentError` on `{:error, reason}`. Backs the `!` variants."
@@ -93,17 +103,22 @@ defmodule Finance.Shared do
     end
   end
 
-  @doc "Net present value of normalized flows at `rate`: `Σ amount / (1 + rate)^t`."
+  @doc """
+  Discount factor for time `t` at `rate`: `(1 + rate)^-t`.
+
+  The negative exponent is deliberate — the divide form `1 / (1 + rate)^t` would
+  overflow its denominator at a high rate over a long horizon, and Erlang's
+  `:math.pow` raises on overflow. This form underflows to a negligible 0 instead,
+  so every discounting site in the library (`present_value`, bond and returns
+  metrics) routes through it. Callers must ensure `1 + rate > 0`.
+  """
+  @spec discount_factor(number, number) :: float
+  def discount_factor(rate, t), do: :math.pow(1 + rate, -t)
+
+  @doc "Net present value of normalized flows at `rate`: `Σ amount · (1 + rate)^-t`."
   @spec present_value([{number, number}], number) :: float
   def present_value(flows, rate) do
-    # Discount with a negative exponent — `amount * (1 + rate)^-t` — rather than
-    # dividing by `(1 + rate)^t`. At a high rate over a long horizon the factor
-    # underflows to 0 (a negligible term, correctly ~0); the divide form would
-    # instead overflow the denominator, and Erlang's `:math.pow` raises on
-    # overflow, which would abort the whole solve.
-    Enum.reduce(flows, 0.0, fn {t, amount}, acc ->
-      acc + amount * :math.pow(1 + rate, -t)
-    end)
+    Enum.reduce(flows, 0.0, fn {t, amount}, acc -> acc + amount * discount_factor(rate, t) end)
   end
 
   # Grid for the bracket scan: grow `1 + rate` by 5% per step, up to a rate of 1e7.
@@ -138,10 +153,10 @@ defmodule Finance.Shared do
     crossed? = straddles_zero?(f_prev, f)
     best = if crossed?, do: closer(best, {prev, rate}, guess), else: best
 
-    # Stop once a sign change is found entirely above the guess: it is the nearest
-    # interval above, `best` already holds the nearest at or below, and everything
-    # further out is farther still.
-    if crossed? and prev >= guess,
+    # Stop at the first sign change reaching the guess: it either contains the guess
+    # (distance 0, unbeatable) or is the nearest interval above it, and `best`
+    # already holds the nearest below — everything further out is farther still.
+    if crossed? and rate >= guess,
       do: finalize(best),
       else: scan(flows, guess, rate, f, grid_step(rate), best)
   end
@@ -149,8 +164,6 @@ defmodule Finance.Shared do
   defp finalize(nil), do: :diverged
   defp finalize({low, high}), do: {:ok, low, high}
 
-  # Keep whichever candidate interval sits nearer `guess`; an interval that
-  # contains the guess wins outright.
   defp closer(nil, interval, _guess), do: interval
 
   defp closer(best, interval, guess) do

--- a/lib/finance/solver/brent.ex
+++ b/lib/finance/solver/brent.ex
@@ -19,7 +19,7 @@ defmodule Finance.Solver.Brent do
 
   @behaviour Finance.Solver
 
-  import Finance.Shared, only: [present_value: 2]
+  import Finance.Shared, only: [present_value: 2, round_value: 2, safely: 1]
 
   # Machine epsilon for doubles, for the convergence tolerance.
   @eps 2.220446049250313e-16
@@ -27,24 +27,13 @@ defmodule Finance.Solver.Brent do
   @impl Finance.Solver
   def solve(flows, opts) do
     case safely(fn -> zbrent(flows, opts) end) do
-      # `+ 0.0` collapses a negative zero (a rate that converges to 0 from below).
-      {:ok, rate} -> {:ok, Float.round(rate, Keyword.fetch!(opts, :precision)) + 0.0}
+      {:ok, rate} -> {:ok, round_value(rate, opts)}
       :diverged -> {:error, :did_not_converge}
     end
   end
 
-  # Pure-Elixir batch: chunk the work across the schedulers (see
-  # `Finance.Shared.solve_batch/2`).
   @impl Finance.Solver
   def solve_many(batch, opts), do: Finance.Shared.solve_batch(batch, &solve(&1, opts))
-
-  # An arithmetic overflow at extreme rates on long-dated flows is treated as a
-  # failure to converge rather than crashing the solve.
-  defp safely(fun) do
-    fun.()
-  rescue
-    ArithmeticError -> :diverged
-  end
 
   defp zbrent(flows, opts) do
     tol = Keyword.fetch!(opts, :tolerance)
@@ -68,8 +57,8 @@ defmodule Finance.Solver.Brent do
 
   defp brent(flows, {a, b, c, fa, fb, fc, d, e}, tol, iters) do
     # Keep c on the far side of the root from b, and make b the closer estimate.
-    {a, c, fa, fc, d, e} =
-      if same_sign?(fb, fc), do: {a, a, fa, fa, b - a, b - a}, else: {a, c, fa, fc, d, e}
+    {c, fc, d, e} =
+      if same_sign?(fb, fc), do: {a, fa, b - a, b - a}, else: {c, fc, d, e}
 
     {a, b, c, fa, fb, fc} =
       if abs(fc) < abs(fb), do: {b, c, b, fb, fc, fb}, else: {a, b, c, fa, fb, fc}

--- a/lib/finance/solver/newton.ex
+++ b/lib/finance/solver/newton.ex
@@ -21,7 +21,7 @@ defmodule Finance.Solver.Newton do
 
   @behaviour Finance.Solver
 
-  import Finance.Shared, only: [present_value: 2]
+  import Finance.Shared, only: [present_value: 2, round_value: 2, safely: 1]
 
   @impl Finance.Solver
   def solve(flows, opts) do
@@ -30,8 +30,7 @@ defmodule Finance.Solver.Newton do
     max_iterations = Keyword.fetch!(opts, :max_iterations)
 
     case safely(fn -> rtsafe(flows, guess, tolerance, max_iterations) end) do
-      # `+ 0.0` collapses a negative zero (a rate that converges to 0 from below).
-      {:ok, rate} -> {:ok, Float.round(rate, Keyword.fetch!(opts, :precision)) + 0.0}
+      {:ok, rate} -> {:ok, round_value(rate, opts)}
       :diverged -> {:error, :did_not_converge}
     end
   end
@@ -41,16 +40,6 @@ defmodule Finance.Solver.Newton do
   @impl Finance.Solver
   def solve_many(batch, opts), do: Finance.Shared.solve_batch(batch, &solve(&1, opts))
 
-  # Arithmetic overflow at extreme rates on long-dated flows is treated as a
-  # failure to converge rather than crashing the solve.
-  defp safely(fun) do
-    fun.()
-  rescue
-    ArithmeticError -> :diverged
-  end
-
-  # Bracket a sign change, then run the safeguarded iteration from `guess` (when it
-  # falls inside the bracket) or the midpoint.
   defp rtsafe(flows, guess, tol, max_iterations) do
     case Finance.Shared.bracket(flows, guess) do
       {:ok, a, b} ->
@@ -86,8 +75,7 @@ defmodule Finance.Solver.Newton do
     end
   end
 
-  # A Newton step when it's usable, a bisection step otherwise. Returns
-  # `{next_x, step}`.
+  # Returns `{next_x, step}`.
   defp move(x, xlo, xhi, f, df, dxold) do
     if newton_usable?(x, xlo, xhi, f, df, dxold) do
       dx = f / df
@@ -98,13 +86,14 @@ defmodule Finance.Solver.Newton do
     end
   end
 
-  # Prefer Newton when the derivative isn't flat, the step lands inside the
-  # bracket, and it shrinks the interval by at least half. Comparing the Newton
-  # point against the bracket — rather than the classic
+  # Prefer Newton when the derivative isn't flat, the step shrinks the interval by
+  # at least half, and it lands inside the bracket. Comparing the Newton point
+  # against the bracket — rather than the classic
   # `((x-xhi)·df - f)·((x-xlo)·df - f)` product — avoids an overflow in the steep
-  # zone near the bracket's floor. `df != 0.0` short-circuits before `x - f / df`.
+  # zone near the bracket's floor. The magnitude test runs before `x - f / df`, so
+  # the division is provably bounded (`|f/df| ≤ |dxold|/2`) when it is computed.
   defp newton_usable?(x, xlo, xhi, f, df, dxold) do
-    df != 0.0 and inside?(x - f / df, xlo, xhi) and abs(2.0 * f) <= abs(dxold * df)
+    df != 0.0 and abs(2.0 * f) <= abs(dxold * df) and inside?(x - f / df, xlo, xhi)
   end
 
   defp inside?(point, xlo, xhi), do: point >= min(xlo, xhi) and point <= max(xlo, xhi)
@@ -115,7 +104,7 @@ defmodule Finance.Solver.Newton do
   # `:math.pow` would raise on) for long-dated flows.
   defp present_value_derivative(flows, rate) do
     Enum.reduce(flows, 0.0, fn {t, amount}, acc ->
-      acc + -t * amount * :math.pow(1 + rate, -(t + 1))
+      acc - t * amount * :math.pow(1 + rate, -(t + 1))
     end)
   end
 end

--- a/lib/finance/tvm.ex
+++ b/lib/finance/tvm.ex
@@ -57,12 +57,11 @@ defmodule Finance.TVM do
   def fv(rate, nper, pmt, pv \\ 0.0, type \\ 0)
       when is_number(rate) and is_number(nper) and is_number(pmt) and is_number(pv) and
              type in [0, 1] do
-    value =
-      if rate == 0,
-        do: -(pv + pmt * nper),
-        else: -(pv * :math.pow(1 + rate, nper) + pmt * annuity(rate, nper, type))
-
-    {:ok, value * 1.0}
+    cond do
+      rate == 0 -> {:ok, -(pv + pmt * nper) + 0.0}
+      1 + rate <= 0 -> {:error, :undefined}
+      true -> {:ok, -(pv * :math.pow(1 + rate, nper) + pmt * annuity(rate, nper, type)) + 0.0}
+    end
   end
 
   @doc "Same as `fv/5`, but returns the value directly and raises `ArgumentError` on error."
@@ -86,12 +85,11 @@ defmodule Finance.TVM do
   def pv(rate, nper, pmt, fv \\ 0.0, type \\ 0)
       when is_number(rate) and is_number(nper) and is_number(pmt) and is_number(fv) and
              type in [0, 1] do
-    value =
-      if rate == 0,
-        do: -(fv + pmt * nper),
-        else: -(fv + pmt * annuity(rate, nper, type)) / :math.pow(1 + rate, nper)
-
-    {:ok, value * 1.0}
+    cond do
+      rate == 0 -> {:ok, -(fv + pmt * nper) + 0.0}
+      1 + rate <= 0 -> {:error, :undefined}
+      true -> {:ok, -(fv + pmt * annuity(rate, nper, type)) / :math.pow(1 + rate, nper) + 0.0}
+    end
   end
 
   @doc "Same as `pv/5`, but returns the value directly and raises `ArgumentError` on error."
@@ -117,8 +115,9 @@ defmodule Finance.TVM do
              type in [0, 1] do
     cond do
       nper == 0 -> {:error, :undefined}
-      rate == 0 -> {:ok, -(pv + fv) / nper * 1.0}
-      true -> {:ok, -(pv * :math.pow(1 + rate, nper) + fv) / annuity(rate, nper, type) * 1.0}
+      rate == 0 -> {:ok, -(pv + fv) / nper + 0.0}
+      1 + rate <= 0 -> {:error, :undefined}
+      true -> {:ok, -(pv * :math.pow(1 + rate, nper) + fv) / annuity(rate, nper, type) + 0.0}
     end
   end
 
@@ -232,14 +231,21 @@ defmodule Finance.TVM do
   def amortization_schedule(rate, nper, pv, opts \\ [])
       when (is_number(rate) or is_struct(rate, Decimal)) and is_number(nper) and
              (is_number(pv) or is_struct(pv, Decimal)) and is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @schedule_options_schema)
     n = trunc(nper)
 
-    if nper == n and n >= 1 do
-      opts = NimbleOptions.validate!(opts, @schedule_options_schema)
+    if valid_loan?(nper, n, pv, rate) do
       {:ok, build_schedule(rate, n, pv, Keyword.fetch!(opts, :precision))}
     else
       {:error, :undefined}
     end
+  end
+
+  # A loan is a whole number of periods with a positive `pv` at a rate above -100%.
+  # Outside that the level payment and the balance clamp are undefined (and `pmt`
+  # can divide by zero), so the schedule is rejected rather than returned wrong.
+  defp valid_loan?(nper, n, pv, rate) do
+    nper == n and n >= 1 and to_float(pv) > 0.0 and to_float(rate) > -1.0
   end
 
   @doc "Same as `amortization_schedule/4`, but returns the rows directly and raises `ArgumentError` on error."
@@ -266,9 +272,21 @@ defmodule Finance.TVM do
     pv = to_float(pv)
     {:ok, payment} = pmt(rate, nper, pv)
 
-    rows = integer_schedule(rate, nper, round(pv * scale), round(payment * scale))
-    converter = if decimal?, do: &row_to_decimal(&1, scale), else: &row_to_float(&1, scale)
-    Enum.map(rows, converter)
+    convert = if decimal?, do: &units_to_decimal(&1, scale), else: &(&1 / scale)
+
+    rate
+    |> integer_schedule(nper, round(pv * scale), round(payment * scale))
+    |> Enum.map(&convert_row(&1, convert))
+  end
+
+  defp convert_row({period, payment, interest, principal, balance}, convert) do
+    %{
+      period: period,
+      payment: convert.(payment),
+      interest: convert.(interest),
+      principal: convert.(principal),
+      balance: convert.(balance)
+    }
   end
 
   # Running balance in integer minor units; the final row pays off whatever
@@ -296,26 +314,6 @@ defmodule Finance.TVM do
   # and never pay off more than is owed (`max(_, -balance)`), so it moves toward
   # zero without overshooting. A normal amortizing payment already falls in range.
   defp clamp_to_balance(scheduled, balance), do: scheduled |> max(-balance) |> min(0)
-
-  defp row_to_float({period, payment, interest, principal, balance}, scale) do
-    %{
-      period: period,
-      payment: payment / scale,
-      interest: interest / scale,
-      principal: principal / scale,
-      balance: balance / scale
-    }
-  end
-
-  defp row_to_decimal({period, payment, interest, principal, balance}, scale) do
-    %{
-      period: period,
-      payment: units_to_decimal(payment, scale),
-      interest: units_to_decimal(interest, scale),
-      principal: units_to_decimal(principal, scale),
-      balance: units_to_decimal(balance, scale)
-    }
-  end
 
   defp units_to_decimal(units, scale), do: Decimal.div(Decimal.new(units), scale)
 
@@ -385,7 +383,7 @@ defmodule Finance.TVM do
     nper |> rate(pmt, pv, fv, type, opts) |> unwrap!()
   end
 
-  # (1 + r·type) · ((1+r)^n − 1) / r — the annuity factor that multiplies pmt.
+  # The annuity factor that multiplies pmt in the moduledoc equation.
   defp annuity(rate, nper, type) do
     (1 + rate * type) * (:math.pow(1 + rate, nper) - 1) / rate
   end
@@ -407,7 +405,7 @@ defmodule Finance.TVM do
     payment_periods = if type == 1, do: 0..(nper - 1), else: 1..nper
 
     payment_periods
-    |> Enum.reduce(%{}, fn i, acc -> Map.update(acc, i * 1.0, pmt * 1.0, &(&1 + pmt)) end)
+    |> Map.new(&{&1 * 1.0, pmt * 1.0})
     |> Map.update(0.0, pv * 1.0, &(&1 + pv))
     |> Map.update(nper * 1.0, fv * 1.0, &(&1 + fv))
     |> Map.to_list()

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Finance.MixProject do
   use Mix.Project
 
-  @version "1.6.0"
+  @version "1.6.1"
   @source_url "https://github.com/tubedude/finance-elixir"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Finance.MixProject do
     [
       app: :finance,
       version: @version,
-      elixir: "~> 1.18",
+      elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       description: description(),

--- a/test/finance_test.exs
+++ b/test/finance_test.exs
@@ -18,6 +18,10 @@ defmodule FinanceTest do
   doctest Finance.Rates
   doctest Finance.Bonds
 
+  # Both shipped solvers must satisfy the same robustness contracts: the fuzz
+  # properties and the pathological corpus run against each.
+  @solvers [Finance.Solver.Newton, Finance.Solver.Brent]
+
   describe "module organization" do
     test "the solver is swappable via the :solver option" do
       assert Finance.CashFlow.irr([-1000, 1100], solver: StubSolver) == {:ok, 0.42}
@@ -141,12 +145,26 @@ defmodule FinanceTest do
       assert_raise NimbleOptions.ValidationError, fn ->
         Finance.CashFlow.npv(0.1, [-1000, 1100], precision: 1.5)
       end
+
+      # precision must be 0..15 — Float.round rejects more, so validation should too
+      assert_raise NimbleOptions.ValidationError, fn ->
+        Finance.CashFlow.irr([-1000, 1100], precision: 16)
+      end
+    end
+
+    test "an integer guess or tolerance is accepted" do
+      assert Finance.CashFlow.irr([-1000, 1100], guess: 1) == {:ok, 0.1}
+      assert {:ok, _rate} = Finance.CashFlow.irr([-1000, 1100], tolerance: 1)
     end
   end
 
   describe "errors" do
     test "mismatched list lengths" do
       assert Finance.CashFlow.xirr([{2014, 4, 15}, {2014, 10, 19}], [-10_000.0, 305.6, 500.0]) ==
+               {:error, :mismatched_lengths}
+
+      # An empty second list is the two-list form with no amounts, not options.
+      assert Finance.CashFlow.xirr([{2014, 4, 15}, {2014, 10, 19}], []) ==
                {:error, :mismatched_lengths}
     end
 
@@ -329,6 +347,10 @@ defmodule FinanceTest do
 
       assert {:ok, rate} = Finance.CashFlow.irr(series)
       assert_in_delta rate, 0.12, 1.0e-4
+
+      # Brent shares the interior-scan bracket, so it clears the even crossing too.
+      assert {:ok, brent} = Finance.CashFlow.irr(series, solver: Finance.Solver.Brent)
+      assert_in_delta brent, 0.12, 1.0e-4
     end
 
     test "the guess selects which root of a multi-IRR series is returned" do
@@ -643,6 +665,12 @@ defmodule FinanceTest do
 
       assert {:ok, rate} = Finance.CashFlow.xirr(flows, precision: 10)
       assert_dated_root(rate, flows)
+
+      # Brent's overflow guard handles the 1e9 magnitudes just as well.
+      assert {:ok, brent} =
+               Finance.CashFlow.xirr(flows, precision: 10, solver: Finance.Solver.Brent)
+
+      assert_dated_root(brent, flows)
     end
   end
 
@@ -807,6 +835,12 @@ defmodule FinanceTest do
       assert Finance.CashFlow.xnpv(0.1, []) == {:error, :insufficient_data}
     end
 
+    test "a rate at or below -100% is undefined, not a crash" do
+      flows = [{~D[2019-01-01], -1000}, {~D[2020-06-15], 1100}]
+      assert Finance.CashFlow.xnpv(-1.0, flows) == {:error, :undefined}
+      assert Finance.CashFlow.xnpv(-1.5, flows) == {:error, :undefined}
+    end
+
     test "xnpv!/2 returns the bare value and raises on error" do
       assert Finance.CashFlow.xnpv!(0.1, [{~D[2019-01-01], -1000}, {~D[2020-01-01], 1100}]) == 0.0
       assert_raise ArgumentError, fn -> Finance.CashFlow.xnpv!(0.1, []) end
@@ -853,6 +887,11 @@ defmodule FinanceTest do
       assert Finance.CashFlow.npv(0.1, []) == {:error, :insufficient_data}
     end
 
+    test "a rate at or below -100% is undefined, not a crash" do
+      assert Finance.CashFlow.npv(-1.0, [-1000, 1100]) == {:error, :undefined}
+      assert Finance.CashFlow.npv(-1.5, [-1000, 1100]) == {:error, :undefined}
+    end
+
     test "npv!/2 returns the bare value" do
       assert Finance.CashFlow.npv!(0.1, [-1000, 1100]) == 0.0
     end
@@ -867,6 +906,11 @@ defmodule FinanceTest do
     test "requires both an inflow and an outflow" do
       assert Finance.CashFlow.mirr([100, 200], 0.1, 0.1) == {:error, :single_signed_flow}
       assert Finance.CashFlow.mirr([-100], 0.1, 0.1) == {:error, :insufficient_data}
+    end
+
+    test "a rate at or below -100% is undefined, not a crash" do
+      assert Finance.CashFlow.mirr([-100, 200], -1.0, 0.1) == {:error, :undefined}
+      assert Finance.CashFlow.mirr([-100, 200], 0.1, -1.5) == {:error, :undefined}
     end
 
     test "mirr!/3 returns the bare rate" do
@@ -982,6 +1026,15 @@ defmodule FinanceTest do
       assert Finance.TVM.rate(10.5, -100, 1000) == {:error, :undefined}
     end
 
+    test "a rate at or below -100% is undefined, not a crash" do
+      assert Finance.TVM.fv(-1.0, 10, -100, 0) == {:error, :undefined}
+      assert Finance.TVM.pv(-1.0, 10, -100, 0) == {:error, :undefined}
+      assert Finance.TVM.pmt(-1.0, 10, 1000) == {:error, :undefined}
+      assert Finance.TVM.fv(-2.0, 10, -100, 0) == {:error, :undefined}
+      assert Finance.TVM.pv(-1.5, 10, -100, 0) == {:error, :undefined}
+      assert Finance.TVM.pmt(-1.5, 10, 1000) == {:error, :undefined}
+    end
+
     test "bang variants return bare values and raise" do
       assert Finance.TVM.fv!(0.0, 10, -100, 0) == 1000.0
       assert Finance.TVM.pv!(0.0, 10, -100, 0) == 1000.0
@@ -1020,6 +1073,7 @@ defmodule FinanceTest do
     test "straight-line spreads the loss evenly" do
       assert Finance.Depreciation.sln(10_000, 1_000, 5) == {:ok, 1800.0}
       assert Finance.Depreciation.sln(10_000, 1_000, 0) == {:error, :undefined}
+      assert Finance.Depreciation.sln(10_000, 1_000, -5) == {:error, :undefined}
       assert Finance.Depreciation.sln!(10_000, 1_000, 5) == 1800.0
     end
 
@@ -1037,6 +1091,8 @@ defmodule FinanceTest do
       assert Finance.Depreciation.syd(10_000, 1_000, 5, 6) == {:error, :undefined}
       assert Finance.Depreciation.syd(10_000, 1_000, 5, 0) == {:error, :undefined}
       assert Finance.Depreciation.syd(10_000, 1_000, 0, 1) == {:error, :undefined}
+      # a fractional period is rejected, matching ddb/db
+      assert Finance.Depreciation.syd(10_000, 1_000, 5, 2.5) == {:error, :undefined}
       assert_raise ArgumentError, fn -> Finance.Depreciation.syd!(10_000, 1_000, 5, 6) end
     end
 
@@ -1111,14 +1167,20 @@ defmodule FinanceTest do
       assert Finance.Returns.discounted_payback_period([-1000, 100, 100], 0.1) ==
                {:error, :undefined}
 
+      # a rate at or below -100% is undefined, not a crash
+      assert Finance.Returns.discounted_payback_period([-1000, 600, 600], -1.0) ==
+               {:error, :undefined}
+
       assert Finance.Returns.discounted_payback_period!([-1000, 600, 600, 600], 0.1) == 1.916667
     end
 
-    test "profitability_index reuses npv" do
+    test "profitability_index" do
       assert Finance.Returns.profitability_index([-1000, 600, 600], 0.1) == {:ok, 1.041322}
       assert Finance.Returns.profitability_index([-1000, 1100], 0.1) == {:ok, 1.0}
       assert Finance.Returns.profitability_index([1000, 600], 0.1) == {:error, :undefined}
       assert Finance.Returns.profitability_index([], 0.1) == {:error, :insufficient_data}
+      # a rate at or below -100% is undefined, not a crash
+      assert Finance.Returns.profitability_index([-1000, 600], -1.0) == {:error, :undefined}
       assert Finance.Returns.profitability_index!([-1000, 600, 600], 0.1) == 1.041322
     end
 
@@ -1128,6 +1190,8 @@ defmodule FinanceTest do
       assert Finance.Returns.twr([0.02, 0.02], periods_per_year: 4) == {:ok, 0.082432}
       assert Finance.Returns.twr([]) == {:error, :insufficient_data}
       assert Finance.Returns.twr([0.1, "x"]) == {:error, :undefined}
+      # a period return below -100% has no meaning
+      assert Finance.Returns.twr([-2.5, 0.1], periods_per_year: 4) == {:error, :undefined}
       assert Finance.Returns.twr!([0.10, -0.05, 0.08]) == 0.1286
       assert_raise ArgumentError, fn -> Finance.Returns.twr!([]) end
     end
@@ -1236,6 +1300,18 @@ defmodule FinanceTest do
       assert Finance.Bonds.ytm(100, 0.05, 100.0, 10) == {:ok, 0.05}
     end
 
+    test "the annual yield is rounded once, not twice through the period rate" do
+      # A discount bond whose period yield sits on a rounding boundary. Rounding
+      # the period rate to :precision and *then* annualizing (the pre-1.6.1 path)
+      # let `freq` carry that rounding into the last reported digit — off by one
+      # unit at freq: 2, and by three at freq: 12. Solving the period rate at high
+      # precision and rounding the product once gives the right last digit.
+      assert Finance.Bonds.ytm(100, 0.03, 83.4, 3, 2) == {:ok, 0.094875}
+      # pre-1.6.1 double-rounding returned 0.094874
+      assert Finance.Bonds.ytm(100, 0.03, 83.4, 3, 12) == {:ok, 0.093687}
+      # pre-1.6.1 double-rounding returned 0.093684
+    end
+
     test "degenerate maturity is undefined across the module" do
       assert Finance.Bonds.price(100, 0.05, 0.05, 0) == {:error, :undefined}
       assert Finance.Bonds.ytm(100, 0.05, 100.0, -1) == {:error, :undefined}
@@ -1245,6 +1321,19 @@ defmodule FinanceTest do
       # a fractional number of coupon periods is also undefined
       assert Finance.Bonds.price(100, 0.05, 0.05, 2.5, 1) == {:error, :undefined}
       assert Finance.Bonds.price(100, 0.05, 0.05, 10, 0) == {:error, :undefined}
+    end
+
+    test "a yield at or below -100% per period is undefined, not a crash" do
+      assert Finance.Bonds.price(100, 0.05, -2.0, 10, 2) == {:error, :undefined}
+      assert Finance.Bonds.price(100, 0.05, -3.0, 10, 2) == {:error, :undefined}
+    end
+
+    test "a negative coupon that zeroes the price makes the risk metrics undefined" do
+      # A steeply negative coupon drives the unit-face price to ~0, so the
+      # divide-by-price in duration/convexity has no meaningful value.
+      assert Finance.Bonds.duration(-0.5, 0.05, 30, 1) == {:error, :undefined}
+      assert Finance.Bonds.modified_duration(-0.5, 0.05, 30, 1) == {:error, :undefined}
+      assert Finance.Bonds.convexity(-0.5, 0.05, 30, 1) == {:error, :undefined}
     end
 
     test "ytm does not converge when no yield brackets the price" do
@@ -1309,8 +1398,13 @@ defmodule FinanceTest do
 
     test "undefined for non-positive frequency or effective <= -1" do
       assert Finance.Rates.effective_annual_rate(0.10, 0) == {:error, :undefined}
+      # A nominal rate so negative the compounded base goes negative (would raise
+      # for a fractional frequency) is undefined, not a crash.
+      assert Finance.Rates.effective_annual_rate(-3.0, 2.5) == {:error, :undefined}
       assert Finance.Rates.nominal_rate(0.10, 0) == {:error, :undefined}
       assert Finance.Rates.nominal_rate(-1.5, 12) == {:error, :undefined}
+      # total loss (effective = -100%) is the inverse of ear = -1, not undefined
+      assert Finance.Rates.nominal_rate(-1.0, 12) == {:ok, -12.0}
       assert Finance.Rates.continuous_to_periodic(0.1, 0) == {:error, :undefined}
     end
 
@@ -1368,6 +1462,14 @@ defmodule FinanceTest do
     test "rejects a non-positive or non-integer term" do
       assert Finance.TVM.amortization_schedule(0.05, 0, 1000) == {:error, :undefined}
       assert Finance.TVM.amortization_schedule(0.05, 2.5, 1000) == {:error, :undefined}
+    end
+
+    test "rejects a non-positive principal or a rate at/below -100%" do
+      # A loan is a positive pv above -100%; outside that the schedule is undefined
+      # (and pmt can divide by zero) — reject rather than return wrong rows.
+      assert Finance.TVM.amortization_schedule(0.05, 12, 0) == {:error, :undefined}
+      assert Finance.TVM.amortization_schedule(0.05, 12, -1000) == {:error, :undefined}
+      assert Finance.TVM.amortization_schedule(-1.0, 12, 1000) == {:error, :undefined}
     end
 
     test "bang variant returns the rows and raises on error" do
@@ -1433,8 +1535,12 @@ defmodule FinanceTest do
         finish = Date.add(start, 365 * years)
         payout = principal * :math.pow(1 + rate, years)
 
-        assert {:ok, found} = Finance.CashFlow.xirr([{start, -principal}, {finish, payout}])
-        assert_in_delta found, rate, 1.0e-3
+        for solver <- @solvers do
+          assert {:ok, found} =
+                   Finance.CashFlow.xirr([{start, -principal}, {finish, payout}], solver: solver)
+
+          assert_in_delta found, rate, 1.0e-3
+        end
       end
     end
 
@@ -1446,16 +1552,18 @@ defmodule FinanceTest do
             ) do
         flows = [{~D[2000-01-01], outflow}, {Date.add(~D[2000-01-01], days), inflow}]
 
-        case Finance.CashFlow.xirr(flows, precision: 10) do
-          # Near a total-loss rate (1 + r ≈ 0) discounting is numerically
-          # singular: tiny rounding in `r` blows up the discount factor. Skip
-          # those degenerate cases — they say nothing about the identity.
-          {:ok, rate} when 1 + rate > 0.01 ->
-            assert {:ok, value} = Finance.CashFlow.xnpv(rate, flows, precision: 10)
-            assert_in_delta value, 0.0, 1.0e-2 * (abs(inflow) + 1)
+        for solver <- @solvers do
+          case Finance.CashFlow.xirr(flows, precision: 10, solver: solver) do
+            # Near a total-loss rate (1 + r ≈ 0) discounting is numerically
+            # singular: tiny rounding in `r` blows up the discount factor. Skip
+            # those degenerate cases — they say nothing about the identity.
+            {:ok, rate} when 1 + rate > 0.01 ->
+              assert {:ok, value} = Finance.CashFlow.xnpv(rate, flows, precision: 10)
+              assert_in_delta value, 0.0, 1.0e-2 * (abs(inflow) + 1)
 
-          _ ->
-            :ok
+            _ ->
+              :ok
+          end
         end
       end
     end
@@ -1471,14 +1579,16 @@ defmodule FinanceTest do
         # A high-precision rate keeps rounding error negligible even where the
         # discount factor is steep; the guard still skips the 1 + r ≈ 0
         # singularity, where any rounding makes the factor explode.
-        case Finance.CashFlow.xirr(flows, precision: 10) do
-          {:ok, rate} when 1 + rate > 0.01 ->
-            t = days / 365.0
-            npv = outflow + inflow / :math.pow(1 + rate, t)
-            assert_in_delta npv, 0.0, 1.0e-2 * (abs(inflow) + 1)
+        for solver <- @solvers do
+          case Finance.CashFlow.xirr(flows, precision: 10, solver: solver) do
+            {:ok, rate} when 1 + rate > 0.01 ->
+              t = days / 365.0
+              npv = outflow + inflow / :math.pow(1 + rate, t)
+              assert_in_delta npv, 0.0, 1.0e-2 * (abs(inflow) + 1)
 
-          _ ->
-            :ok
+            _ ->
+              :ok
+          end
         end
       end
     end
@@ -1498,13 +1608,15 @@ defmodule FinanceTest do
         outlay = present_value_at(rate, Enum.with_index(inflows, 1))
         flows = [-outlay | inflows]
 
-        case Finance.CashFlow.irr(flows, precision: 12) do
-          {:ok, found} ->
-            npv = present_value_at(found, Enum.with_index(flows, 0))
-            assert_in_delta npv, 0.0, 1.0e-4 * (abs(outlay) + 1)
+        for solver <- @solvers do
+          case Finance.CashFlow.irr(flows, precision: 12, solver: solver) do
+            {:ok, found} ->
+              npv = present_value_at(found, Enum.with_index(flows, 0))
+              assert_in_delta npv, 0.0, 1.0e-4 * (abs(outlay) + 1)
 
-          {:error, reason} ->
-            assert reason in [:did_not_converge, :single_signed_flow, :insufficient_data]
+            {:error, reason} ->
+              assert reason in [:did_not_converge, :single_signed_flow, :insufficient_data]
+          end
         end
       end
     end
@@ -1515,20 +1627,22 @@ defmodule FinanceTest do
     # (a real root) or one of the documented errors.
     property "irr never crashes on arbitrary flows; any rate it returns brackets a real root" do
       check all(amounts <- list_of(integer(-1_000_000..1_000_000), max_length: 30)) do
-        case Finance.CashFlow.irr(amounts, precision: 10) do
-          {:ok, rate} ->
-            assert is_float(rate) and rate > -1.0
-            indexed = Enum.with_index(amounts, 0)
-            # Assert a zero-crossing rather than the NPV magnitude: a steep NPV is
-            # large even a hair from its root, whereas a spurious non-root shows
-            # no crossing at all. The window sits well inside the (-1, ∞) domain.
-            h = min(max(abs(rate), 1.0) * 1.0e-6, (1.0 + rate) / 2)
-            below = present_value_at(rate - h, indexed)
-            above = present_value_at(rate + h, indexed)
-            assert (below <= 0 and above >= 0) or (below >= 0 and above <= 0)
+        for solver <- @solvers do
+          case Finance.CashFlow.irr(amounts, precision: 10, solver: solver) do
+            {:ok, rate} ->
+              assert is_float(rate) and rate > -1.0
+              indexed = Enum.with_index(amounts, 0)
+              # Assert a zero-crossing rather than the NPV magnitude: a steep NPV is
+              # large even a hair from its root, whereas a spurious non-root shows
+              # no crossing at all. The window sits well inside the (-1, ∞) domain.
+              h = min(max(abs(rate), 1.0) * 1.0e-6, (1.0 + rate) / 2)
+              below = present_value_at(rate - h, indexed)
+              above = present_value_at(rate + h, indexed)
+              assert (below <= 0 and above >= 0) or (below >= 0 and above <= 0)
 
-          {:error, reason} ->
-            assert reason in [:insufficient_data, :single_signed_flow, :did_not_converge]
+            {:error, reason} ->
+              assert reason in [:insufficient_data, :single_signed_flow, :did_not_converge]
+          end
         end
       end
     end
@@ -1543,8 +1657,49 @@ defmodule FinanceTest do
             ) do
         rate = rate_bp / 10_000
         assert {:ok, pv} = Finance.TVM.pv(rate, nper, pmt, 0.0, 0)
-        assert {:ok, found} = Finance.TVM.rate(nper, pmt, pv, 0.0, 0, precision: 10)
-        assert_in_delta found, rate, 1.0e-4
+
+        for solver <- @solvers do
+          assert {:ok, found} =
+                   Finance.TVM.rate(nper, pmt, pv, 0.0, 0, precision: 10, solver: solver)
+
+          assert_in_delta found, rate, 1.0e-4
+        end
+      end
+    end
+
+    # The dated (XIRR) analog of the arbitrary-flows property above: long,
+    # irregularly-spaced series with random signs — exercising `normalize/1`'s
+    # date→year conversion, same-date merging, and the solver over non-integer
+    # spacing. Whatever the solver returns must bracket a real XNPV root.
+    property "xirr on long, irregularly-spaced, random-sign flows brackets a real XNPV root" do
+      check all(
+              raw <-
+                list_of(tuple({integer(0..7300), integer(-1_000_000..1_000_000)}),
+                  min_length: 2,
+                  max_length: 30
+                ),
+              max_runs: 200
+            ) do
+        base = ~D[2000-01-01]
+        flows = Enum.map(raw, fn {day, amount} -> {Date.add(base, day), amount} end)
+
+        for solver <- @solvers do
+          case Finance.CashFlow.xirr(flows, precision: 12, solver: solver) do
+            {:ok, rate} when 1 + rate > 0.01 ->
+              # Sign change of the XNPV around the root, not its magnitude — steep
+              # roots are large a hair away, while a spurious non-root never crosses.
+              h = min(max(abs(rate), 1.0) * 1.0e-6, (1.0 + rate) / 2)
+              {:ok, below} = Finance.CashFlow.xnpv(rate - h, flows, precision: 12)
+              {:ok, above} = Finance.CashFlow.xnpv(rate + h, flows, precision: 12)
+              assert (below <= 0 and above >= 0) or (below >= 0 and above <= 0)
+
+            {:ok, _rate} ->
+              :ok
+
+            {:error, reason} ->
+              assert reason in [:did_not_converge, :single_signed_flow, :insufficient_data]
+          end
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

This release hardens the library against edge cases where rates at or below -100% would cause arithmetic errors or nonsensical results. It also fixes a double-rounding bug in bond yield calculations and improves validation of input parameters.

## Key Changes

**Rate validation (the main fix)**
- All functions that compute `(1 + rate)^t` now validate that `1 + rate > 0` and return `{:error, :undefined}` instead of raising `ArithmeticError` or returning garbage. This includes:
  - `CashFlow.xnpv`, `npv`, `mirr`
  - `TVM.fv`, `pv`, `pmt`, `amortization_schedule`
  - `Bonds.price` and risk metrics (`duration`, `modified_duration`, `convexity`)
  - `Returns.discounted_payback_period`, `profitability_index`, `twr`
  - `Rates.effective_annual_rate`
  - `Depreciation.sln` (also now rejects non-positive `life`)
- `Rates.nominal_rate(-1.0, m)` now correctly returns `-m` (total loss), staying the exact inverse of `effective_annual_rate`

**Bond yield rounding fix**
- `Bonds.ytm` now solves the per-period rate at high precision (≥12 decimals) and rounds the annualized yield once, rather than rounding the period rate first and then multiplying by `freq`. The old path let `freq` amplify rounding error into the last reported digit (off by 1–3 units depending on frequency).
- `Returns.profitability_index` similarly computes at full precision before the final round

**Input validation improvements**
- `:precision` is now validated as `0..15` (the range `Float.round/2` accepts) instead of any non-negative integer
- `:guess` and `:tolerance` now accept integers as well as floats
- `Bonds` functions now require an integer `freq` (matching the documented `pos_integer` type)
- `Depreciation.syd` rejects fractional `period` values, matching `ddb`/`db`
- `xirr(dates, [])` now correctly returns `{:error, :mismatched_lengths}` instead of crashing (empty amounts list is the two-list form, not options)

**Discounting refactor**
- Centralized overflow-safe discounting in a new `discount_factor(rate, t)` helper that computes `(1 + rate)^-t` (negative exponent). This avoids the divide form `1 / (1 + rate)^t` which would overflow its denominator at high rates over long horizons. All bond and returns metrics now route through this helper.
- Moved the `safely/1` wrapper (which catches `ArithmeticError` and maps it to `:diverged`) to `Finance.Shared` so both solvers use it consistently

**Date parsing robustness**
- `CashFlow.xirr` now uses `Date.from_erl/1` instead of a broad `rescue`, so malformed amounts raise immediately (a caller error) rather than being mislabeled as `{:error, :invalid_date}`

**Test coverage**
- Added `@solvers` list to run fuzz properties and pathological corpus tests against both Newton and Brent solvers, ensuring both satisfy the same robustness contracts
- Extended test suite with edge cases for rates at/below -100%, negative coupons, and degenerate inputs

## Notable Implementation Details

- The bracket scan in the solver now stops one step sooner when the root sits exactly at the guess, improving efficiency
- Bond risk metrics (`duration`, `modified_duration`, `convexity`) now return `{:error, :undefined}` when a negative coupon drives the unit-face price to zero, rather than a nonsensical value or crash
- `TVM.amortization_schedule` validates that the principal is positive and the rate is above -100% before building the schedule, preventing undefined payment calculations
- All rate-dependent calculations now use a consistent guard: `1 + rate > 0` (or

https://claude.ai/code/session_01AVibXT2w1dEdVtMHqffFKn